### PR TITLE
Introduce build inside the docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:trusty
+
+# requirements from README
+RUN apt-get update && apt-get install -y \
+        curl \
+        git \
+        gcc \
+        libnl-3-dev libnl-genl-3-dev \
+        make \
+        protobuf-compiler
+
+# Install Go
+ENV GO_VERSION 1.5.3
+RUN curl -fsSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" \
+    | tar -xzC /usr/local
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV GOPATH /go
+
+RUN go get -u golang.org/x/crypto/ssh; \
+    go get -u github.com/dlintw/goconf; \
+    go get -u github.com/golang/glog; \
+    go get -u github.com/golang/protobuf/proto; \
+    go get -u github.com/golang/protobuf/protoc-gen-go; \
+    go get -u github.com/miekg/dns
+
+COPY . /go/src/github.com/google/seesaw
+
+WORKDIR /go/src/github.com/google/seesaw
+
+CMD ["/bin/sh", "-c", "make test; make install; hack/prepare_out.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM debian:jessie
 
 # requirements from README
 RUN apt-get update && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ four interfaces should be connected to the same layer 2 network.
 
 ## Building
 
+### automatic build inside Docker
+
+In order to build seesaw inside the docker environment, one should run following command:
+
+    hack/build.sh 
+
+as a result of execution, you will get binaries in the `_out` folder, which will be created automatically.
+
+
+### manual build
+
 Seesaw v2 is developed in Go and depends on several Go packages:
 
 - [golang.org/x/crypto/ssh](http://godoc.org/golang.org/x/crypto/ssh)
@@ -55,6 +66,8 @@ Ensure that `${GOPATH}/bin` is in your `${PATH}` and in the seesaw directory:
     make install
 
 ## Installing
+
+In case you executed docker based build, your binaries are located in `_out` dir insdead of `${GOPATH}/bin`. You need to adjust paths below accordingly. 
 
 After `make install` has run successfully, there should be a number of
 binaries in `${GOPATH}/bin` with a `seesaw_` prefix. Install these to the

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -5,7 +5,7 @@ SCRIPT=$(readlink -f "${BASH_SOURCE[0]}")
 cd $(dirname $SCRIPT)
 mkdir -p ../_out
 rm -f ../_out/*
-docker build -t 'seewas-dev:master'  ../
+docker build -t 'seesaw-dev:master'  ../
 echo $HACK_DIR
-docker run -i -t --rm=true -v $(readlink -f ../_out):/go/bin/out seewas-dev:master
+docker run -i -t --rm=true -v $(readlink -f ../_out):/go/bin/out seesaw-dev:master
 cd $OLD_PWD

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+OLD_PWD=`pwd`
+SCRIPT=$(readlink -f "${BASH_SOURCE[0]}")
+cd $(dirname $SCRIPT)
+mkdir -p ../_out
+rm -f ../_out/*
+docker build -t 'seewas-dev:master'  ../
+echo $HACK_DIR
+docker run -i -t --rm=true -v $(readlink -f ../_out):/go/bin/out seewas-dev:master
+cd $OLD_PWD

--- a/hack/prepare_out.sh
+++ b/hack/prepare_out.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p "${GOPATH}/bin/out/"
+
+for component in {ecu,engine,ha,healthcheck,ncc,watchdog}; do
+    install "/go/bin/seesaw_${component}" "/go/bin/out/"
+done


### PR DESCRIPTION
This should simplify adoption by the community, and may save couple of
hours for new users who would like to just try the tool without
additional efforts.