### PR TITLE
Improve engine tracking of configured VIP addresses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ After setting `GOPATH` to an appropriate location (for example `~/go`):
     go get -u github.com/golang/glog
     go get -u github.com/golang/protobuf/{proto,protoc-gen-go}
     go get -u github.com/miekg/dns
+    go get -u github.com/kylelemons/godebug/pretty
 
 Ensure that `${GOPATH}/bin` is in your `${PATH}` and in the seesaw directory:
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -20,6 +20,7 @@ package engine
 // engine tests.
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/google/seesaw/common/seesaw"
@@ -27,6 +28,8 @@ import (
 	ncclient "github.com/google/seesaw/ncc/client"
 	ncctypes "github.com/google/seesaw/ncc/types"
 	"github.com/google/seesaw/quagga"
+
+	log "github.com/golang/glog"
 )
 
 type dummyNCC struct{}
@@ -53,22 +56,76 @@ func (nc *dummyNCC) IPVSUpdateDestination(svc *ipvs.Service, dst *ipvs.Destinati
 func (nc *dummyNCC) IPVSDeleteDestination(svc *ipvs.Service, dst *ipvs.Destination) error { return nil }
 func (nc *dummyNCC) RouteDefaultIPv4() (net.IP, error)                                    { return nil, nil }
 
-type dummyLBInterface struct{}
+type dummyLBInterface struct {
+	vips     map[seesaw.VIP]bool
+	vlans    map[uint16]bool
+	vservers map[string]map[seesaw.AF]bool
+}
 
-func (lb *dummyLBInterface) Init() error                                         { return nil }
-func (lb *dummyLBInterface) Up() error                                           { return nil }
-func (lb *dummyLBInterface) Down() error                                         { return nil }
-func (lb *dummyLBInterface) AddVIP(vip *seesaw.VIP) error                        { return nil }
-func (lb *dummyLBInterface) DeleteVIP(vip *seesaw.VIP) error                     { return nil }
-func (lb *dummyLBInterface) AddVLAN(vlan *seesaw.VLAN) error                     { return nil }
-func (lb *dummyLBInterface) DeleteVLAN(vlan *seesaw.VLAN) error                  { return nil }
-func (lb *dummyLBInterface) AddVserver(v *seesaw.Vserver, af seesaw.AF) error    { return nil }
-func (lb *dummyLBInterface) DeleteVserver(v *seesaw.Vserver, af seesaw.AF) error { return nil }
+func newDummyLBInterface() *dummyLBInterface {
+	return &dummyLBInterface{
+		make(map[seesaw.VIP]bool),
+		make(map[uint16]bool),
+		make(map[string]map[seesaw.AF]bool),
+	}
+}
+
+func (lb *dummyLBInterface) Init() error { return nil }
+func (lb *dummyLBInterface) Up() error   { return nil }
+func (lb *dummyLBInterface) Down() error { return nil }
+func (lb *dummyLBInterface) AddVIP(vip *seesaw.VIP) error {
+	log.Infof("Adding vip %v", vip)
+	lb.vips[*vip] = true
+	return nil
+}
+func (lb *dummyLBInterface) DeleteVIP(vip *seesaw.VIP) error {
+	log.Infof("Deleting vip %v", vip)
+	if _, ok := lb.vips[*vip]; !ok {
+		return fmt.Errorf("deleting non-existent VIP: %v", vip)
+	}
+	delete(lb.vips, *vip)
+	return nil
+}
+func (lb *dummyLBInterface) AddVLAN(vlan *seesaw.VLAN) error {
+	lb.vlans[vlan.Key()] = true
+	return nil
+}
+func (lb *dummyLBInterface) DeleteVLAN(vlan *seesaw.VLAN) error {
+	if _, ok := lb.vlans[vlan.Key()]; !ok {
+		return fmt.Errorf("deleting non-existent VLAN: %v", vlan)
+	}
+	delete(lb.vlans, vlan.Key())
+	return nil
+}
+func (lb *dummyLBInterface) AddVserver(v *seesaw.Vserver, af seesaw.AF) error {
+	log.Infof("Adding vserver %v", v)
+	afMap, ok := lb.vservers[v.Name]
+	if !ok {
+		afMap = make(map[seesaw.AF]bool)
+		lb.vservers[v.Name] = afMap
+	}
+	afMap[af] = true
+	return nil
+}
+func (lb *dummyLBInterface) DeleteVserver(v *seesaw.Vserver, af seesaw.AF) error {
+	log.Infof("Deleting vserver %v", v)
+	if afMap, ok := lb.vservers[v.Name]; !ok {
+		return fmt.Errorf("deleting non-existent Vserver: %v", v)
+	} else if _, ok := afMap[af]; !ok {
+		return fmt.Errorf("deleting wrong AF for Vserver %v: %v", v, af)
+	} else {
+		delete(afMap, af)
+		if len(afMap) == 0 {
+			delete(lb.vservers, v.Name)
+		}
+	}
+	return nil
+}
 
 func newTestEngine() *Engine {
 	e := NewEngine(nil)
 	e.ncc = &dummyNCC{}
-	e.lbInterface = &dummyLBInterface{}
+	e.lbInterface = newDummyLBInterface()
 	return e
 }
 

--- a/engine/testdata/re-ip/config_1.pb
+++ b/engine/testdata/re-ip/config_1.pb
@@ -1,0 +1,33 @@
+seesaw_vip <
+  fqdn: "seesaw-vip1.example.com."
+  ipv4: "192.168.36.16/26"
+  status: PRODUCTION
+>
+vserver <
+  name: "dns.resolver@au-syd"
+  rp: "foo"
+  entry_address <
+    fqdn: "dns-vip1.example.com."
+    ipv4: "192.168.36.1/24"
+    status: PRODUCTION
+  >
+  vserver_entry <
+    protocol: UDP
+    port: 53
+    persistence: 100
+    healthcheck <
+      type: HTTP
+      send: "foo"
+      receive: "bar"
+      code: 200
+      mode: DSR
+    >
+  >
+  backend: <
+    host: <
+      fqdn: "dns1-1.example.com."
+      ipv4: "192.168.37.2/26"
+      status: PRODUCTION
+    >
+  >
+>

--- a/engine/testdata/re-ip/config_2.pb
+++ b/engine/testdata/re-ip/config_2.pb
@@ -1,0 +1,33 @@
+seesaw_vip <
+  fqdn: "seesaw-vip1.example.com."
+  ipv4: "192.168.36.16/26"
+  status: PRODUCTION
+>
+vserver <
+  name: "dns.resolver@au-syd"
+  rp: "foo"
+  entry_address <
+    fqdn: "dns-vip1.example.com."
+    ipv4: "192.168.36.5/24"
+    status: PRODUCTION
+  >
+  vserver_entry <
+    protocol: UDP
+    port: 53
+    persistence: 100
+    healthcheck <
+      type: HTTP
+      send: "foo"
+      receive: "bar"
+      code: 200
+      mode: DSR
+    >
+  >
+  backend: <
+    host: <
+      fqdn: "dns1-1.example.com."
+      ipv4: "192.168.37.2/26"
+      status: PRODUCTION
+    >
+  >
+>

--- a/engine/testdata/re-ip/config_3.pb
+++ b/engine/testdata/re-ip/config_3.pb
@@ -1,0 +1,33 @@
+seesaw_vip <
+  fqdn: "seesaw-vip1.example.com."
+  ipv4: "192.168.36.16/26"
+  status: PRODUCTION
+>
+vserver <
+  name: "dns.resolver@au-syd"
+  rp: "foo"
+  entry_address <
+    fqdn: "dns-vip1.example.com."
+    ipv4: "192.168.36.5/24"
+    status: DISABLED
+  >
+  vserver_entry <
+    protocol: UDP
+    port: 53
+    persistence: 100
+    healthcheck <
+      type: HTTP
+      send: "foo"
+      receive: "bar"
+      code: 200
+      mode: DSR
+    >
+  >
+  backend: <
+    host: <
+      fqdn: "dns1-1.example.com."
+      ipv4: "192.168.37.2/26"
+      status: DISABLED
+    >
+  >
+>

--- a/engine/testdata/re-ip/config_4.pb
+++ b/engine/testdata/re-ip/config_4.pb
@@ -1,0 +1,33 @@
+seesaw_vip <
+  fqdn: "seesaw-vip1.example.com."
+  ipv4: "192.168.36.16/26"
+  status: PRODUCTION
+>
+vserver <
+  name: "dns.resolver@au-syd"
+  rp: "foo"
+  entry_address <
+    fqdn: "dns-anycast.example.com."
+    ipv4: "192.168.255.1/24"
+    status: PRODUCTION
+  >
+  vserver_entry <
+    protocol: UDP
+    port: 53
+    persistence: 100
+    healthcheck <
+      type: HTTP
+      send: "foo"
+      receive: "bar"
+      code: 200
+      mode: DSR
+    >
+  >
+  backend: <
+    host: <
+      fqdn: "dns1-1.example.com."
+      ipv4: "192.168.37.2/26"
+      status: PRODUCTION
+    >
+  >
+>

--- a/engine/testdata/re-ip/config_5.pb
+++ b/engine/testdata/re-ip/config_5.pb
@@ -1,0 +1,33 @@
+seesaw_vip <
+  fqdn: "seesaw-vip1.example.com."
+  ipv4: "192.168.36.16/26"
+  status: PRODUCTION
+>
+vserver <
+  name: "dns.resolver@au-syd"
+  rp: "foo"
+  entry_address <
+    fqdn: "dns-anycast.example.com."
+    ipv4: "192.168.255.1/24"
+    status: DISABLED
+  >
+  vserver_entry <
+    protocol: UDP
+    port: 53
+    persistence: 100
+    healthcheck <
+      type: HTTP
+      send: "foo"
+      receive: "bar"
+      code: 200
+      mode: DSR
+    >
+  >
+  backend: <
+    host: <
+      fqdn: "dns1-1.example.com."
+      ipv4: "192.168.37.2/26"
+      status: DISABLED
+    >
+  >
+>


### PR DESCRIPTION
Otherwise the engine can leave configured (and try to act upon) no
longer used VIP addresses.

- When receiving a vserver config update, check that the previously
  configured unicast VIP addresses are still needed, and remove them if
  not.
- Better document relevant vserver fields.
- Ensure vips and lbVservers maps are in-sync with the interface by
  pruning as necessary.
- Implement a stub lb interface for testing that allows introspection of
  live configuration.
- Use it to validate state during a re-ip transition.
- Other minor test style cleanup.