### PR TITLE
Fix target IP address in serialized ARP message

### DIFF
--- a/ncc/arp.go
+++ b/ncc/arp.go
@@ -75,7 +75,7 @@ func (m *arpMessage) bytes() ([]byte, error) {
 	buf.Write(m.senderHardwareAddress)
 	buf.Write(m.senderProtocolAddress)
 	buf.Write(m.targetHardwareAddress)
-	buf.Write(m.targetHardwareAddress)
+	buf.Write(m.targetProtocolAddress)
 
 	return buf.Bytes(), nil
 }


### PR DESCRIPTION
When an ARP message is serialized to bytes the target MAC address (`FF:FF:FF:FF:FF`) is used in place of the target IP address.

This fixes it so that the correct struct member is used for the target IP address.