### PR TITLE
seesaw/engine/config: remove google.com domain restriction for config servers

### DIFF
--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -25,7 +25,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"time"
 
@@ -36,15 +35,11 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-var (
-	configServerRE = regexp.MustCompile(`^[\w-\.]+\.google\.com\.?$`)
-
-	defaultArchiveConfig = archiveConfig{
-		age:   60 * 24 * time.Hour,
-		bytes: 10 * 1 << 30,
-		count: 1500,
-	}
-)
+var defaultArchiveConfig = archiveConfig{
+	age:   60 * 24 * time.Hour,
+	bytes: 10 * 1 << 30,
+	count: 1500,
+}
 
 // Source specifies a source of configuration information.
 type Source int

--- a/engine/config/fetcher.go
+++ b/engine/config/fetcher.go
@@ -147,10 +147,6 @@ func fetchConfig(f *fetcher, host string, ip net.IP) (string, []byte, error) {
 
 func (f *fetcher) fetch(handler fetchHandler) (string, []byte, error) {
 	for _, server := range f.servers {
-		if !configServerRE.MatchString(server) {
-			log.Errorf("Invalid config server name: %q", server)
-			continue
-		}
 		// TODO(angusc): Resolve and cache the IP address for each server so we have
 		// a fallback in case DNS is down.
 		addrs, err := net.LookupIP(server)


### PR DESCRIPTION
Currently, config servers must be specified under a google.com domain - remove this restriction since it is impractical for open source use.