### PR TITLE
fixed: take 1-255 as valid VRID.

### DIFF
--- a/binaries/seesaw_engine/main.go
+++ b/binaries/seesaw_engine/main.go
@@ -121,8 +121,8 @@ func main() {
 		if err != nil {
 			log.Exitf("Unable to get VRID: %v", err)
 		}
-		if id < 0 || id > 255 {
-			log.Exitf("Invalid VRID %d - must be between 0 and 255 inclusive", id)
+		if id < 1 || id > 255 {
+			log.Exitf("Invalid VRID %d - must be between 1 and 255 inclusive", id)
 		}
 		vrid = uint8(id)
 	}

--- a/test_tools/ncc_test_tool/main.go
+++ b/test_tools/ncc_test_tool/main.go
@@ -134,7 +134,7 @@ func lbInterface(ncc client.NCC) client.LBInterface {
 	if vip == nil {
 		log.Fatalf("Invalid cluster VIP - %q", *clusterVIPStr)
 	}
-	if *vrID < 0 || *vrID > 255 {
+	if *vrID < 1 || *vrID > 255 {
 		log.Fatalf("Invalid VRID - %q", *vrID)
 	}
 	rtID := uint8(*routingTableID)


### PR DESCRIPTION
[RFC5798](https://tools.ietf.org/html/rfc5798) say.

```
6.1.  Parameters Per Virtual Router

   VRID                        Virtual Router Identifier.  Configurable
                               item in the range 1-255 (decimal).  There
                               is no default.
```

So, I think zero is a invalid value as VRID.

Best regards,

