### PR TITLE
Avoiding offending the cgo runtime pointer check.

### DIFF
--- a/netlink/cfuncs.go
+++ b/netlink/cfuncs.go
@@ -17,13 +17,23 @@ package netlink
 /*
 #cgo CFLAGS: -I/usr/include/libnl3
 
+#include <stdint.h>
+
 #include <netlink/netlink.h>
 
+// Forward declaration of Go callback trampoline.
 int callback(struct nl_msg *msg, void *arg);
 
-int callbackGateway(struct nl_msg *msg, void *arg)
-{
+int callbackGateway(struct nl_msg *msg, void *arg) {
 	return callback(msg, arg);
+}
+
+// Wrapper around the equivalent libnl function to provide a cgo-friendly
+// callback arg.
+int _nl_socket_modify_cb(struct nl_sock *sk, enum nl_cb_type type,
+                         enum nl_cb_kind kind, nl_recvmsg_msg_cb_t func,
+                         uintptr_t arg) {
+	return nl_socket_modify_cb(sk, type, kind, func, (void*)arg);
 }
 */
 import "C"

--- a/netlink/message.go
+++ b/netlink/message.go
@@ -31,7 +31,11 @@ import (
 #include <netlink/netlink.h>
 #include <netlink/genl/genl.h>
 
+// Forward declarations for cfuncs.go.
 int callbackGateway(struct nl_msg *msg, void *arg);
+int _nl_socket_modify_cb(struct nl_sock *sk, enum nl_cb_type type,
+                         enum nl_cb_kind kind, nl_recvmsg_msg_cb_t func,
+                         uintptr_t arg);
 */
 import "C"
 
@@ -241,7 +245,7 @@ func (m *Message) SendCallback(fn CallbackFunc, arg interface{}) error {
 	cbID := registerCallback(cbArg)
 	defer unregisterCallback(cbArg)
 
-	if errno := C.nl_socket_modify_cb(s.nls, C.NL_CB_VALID, C.NL_CB_CUSTOM, (C.nl_recvmsg_msg_cb_t)(unsafe.Pointer(C.callbackGateway)), unsafe.Pointer(cbID)); errno != 0 {
+	if errno := C.nl_socket_modify_cb(s.nls, C.NL_CB_VALID, C.NL_CB_CUSTOM, (C.nl_recvmsg_msg_cb_t)(unsafe.Pointer(C.callbackGateway)), C.uintptr_t(cbID)); errno != 0 {
 		return &Error{errno, "failed to modify callback"}
 	}
 	// nl_send_auto_complete returns number of bytes sent or a negative


### PR DESCRIPTION
We need to let libnl hold our callback identifier (just a numeric map key),
passed as a C void*. cgo expects C void* params's to get Go unsafe.Pointer
args, but does a runtime check to see if the value points at another Go
pointer.

By adding a C-side wrapper with a pure numeric signature, we no longer have to
use unsafe.Pointer Go side, so we avoid the runtime check.