### PR TITLE
Make `make test` pass with Go 1.11

### DIFF
--- a/engine/vserver_test.go
+++ b/engine/vserver_test.go
@@ -969,7 +969,7 @@ func TestVserverSnapshot(t *testing.T) {
 		t.Errorf("Snapshot name mismatch - got %s, want %s", got, want)
 	}
 	if got, want := snapshot.Enabled, expectedSnapshot.Enabled; got != want {
-		t.Errorf("Snapshot enabled mismatch - got %s, want %s", got, want)
+		t.Errorf("Snapshot enabled mismatch - got %t, want %t", got, want)
 	}
 	if got, want := snapshot.Host, expectedSnapshot.Host; !reflect.DeepEqual(got, want) {
 		t.Errorf("Snapshot vserver host mismatch - got %#v, want %#v", got, want)

--- a/healthcheck/dns.go
+++ b/healthcheck/dns.go
@@ -140,7 +140,7 @@ func (hc *DNSChecker) Check(timeout time.Duration) *Result {
 		return complete(start, msg, false, nil)
 	}
 	if rc := r.Rcode; rc != dns.RcodeSuccess {
-		msg = fmt.Sprintf("%s; non-zero response code - %s", msg, rc)
+		msg = fmt.Sprintf("%s; non-zero response code - %d", msg, rc)
 		return complete(start, msg, false, nil)
 	}
 	if len(r.Answer) < 1 {

--- a/healthcheck/http.go
+++ b/healthcheck/http.go
@@ -101,7 +101,7 @@ func (hc *HTTPChecker) Check(timeout time.Duration) *Result {
 		u.Scheme = "http"
 	}
 	if u.Host == "" {
-		u.Host = hc.IP.String()
+		u.Host = hc.addr()
 	}
 
 	proxy := (func(*http.Request) (*url.URL, error))(nil)


### PR DESCRIPTION
fix `HTTPChecker` request url and fmt verbs