### PR TITLE
Set arp_announce and arp_ignore

### DIFF
--- a/ncc/sysctl.go
+++ b/ncc/sysctl.go
@@ -66,6 +66,8 @@ var seesawIfaceSysctls = []struct {
 
 	// Only respond to ARP requests via the interface the IP belongs to.
 	{seesaw.IPv4, "arp_filter", "1"},
+	{seesaw.IPv4, "arp_ignore", "1"},
+	{seesaw.IPv4, "arp_announce", "2"},
 
 	// Generate gratuitous ARP messages when interface is brought up.
 	{seesaw.IPv4, "arp_notify", "1"},


### PR DESCRIPTION
commit 70f4d6e07364ce26b3c622ec40c06bf604874dc6 doesn't fix arp flux
completely on the backup node.

ref:
http: //kb.linuxvirtualserver.org/wiki/Using_arp_announce/arp_ignore_to_disable_ARP