### PR TITLE
add timeout to syncClient

### DIFF
--- a/engine/sync.go
+++ b/engine/sync.go
@@ -380,7 +380,11 @@ func (sc *syncClient) dial() error {
 	self := &net.TCPAddr{
 		IP: sc.engine.config.Node.IPv4Addr,
 	}
-	conn, err := net.DialTCP("tcp", self, peer)
+	d := net.Dialer{
+		Timeout:   time.Second * 2,
+		LocalAddr: self,
+	}
+	conn, err := d.Dial("tcp", peer.String())
 	if err != nil {
 		return fmt.Errorf("failed to connect: %v", err)
 	}


### PR DESCRIPTION
The lock is held when dialing which blocks all other functions on
syncClient. Adding a timeout can remit it a bit.