### PR TITLE
sync healthcheck status from master to backup

### DIFF
--- a/engine/core.go
+++ b/engine/core.go
@@ -623,11 +623,6 @@ func (e *Engine) becomeBackup() {
 	if err := e.lbInterface.Down(); err != nil {
 		log.Fatalf("Failed to bring LB interface down: %v", err)
 	}
-
-	// TODO(jsing): Once peer synchronisation is implemented, make this
-	// a time-based expiration that commences once communication with the
-	// peer is lost.
-	e.hcManager.expire()
 }
 
 // markAllocator handles the allocation of marks.

--- a/engine/healthcheck_test.go
+++ b/engine/healthcheck_test.go
@@ -75,52 +75,52 @@ var (
 		},
 	}
 
-	key1 = checkKey{
-		vserverIP:       seesaw.ParseIP("1.1.1.1"),
-		backendIP:       seesaw.ParseIP("1.1.1.2"),
-		healthcheckType: seesaw.HCTypeHTTP,
-		healthcheckPort: 3901,
-		name:            "HTTP/3901_0",
+	key1 = CheckKey{
+		VserverIP:       seesaw.ParseIP("1.1.1.1"),
+		BackendIP:       seesaw.ParseIP("1.1.1.2"),
+		HealthcheckType: seesaw.HCTypeHTTP,
+		HealthcheckPort: 3901,
+		Name:            "HTTP/3901_0",
 	}
 
-	key2 = checkKey{
-		vserverIP:       seesaw.ParseIP("2012::cafe"),
-		backendIP:       seesaw.ParseIP("2012::cafd"),
-		healthcheckType: seesaw.HCTypeHTTP,
-		healthcheckPort: 3901,
-		name:            "HTTP/3901_0",
+	key2 = CheckKey{
+		VserverIP:       seesaw.ParseIP("2012::cafe"),
+		BackendIP:       seesaw.ParseIP("2012::cafd"),
+		HealthcheckType: seesaw.HCTypeHTTP,
+		HealthcheckPort: 3901,
+		Name:            "HTTP/3901_0",
 	}
 
-	key3 = checkKey{
-		vserverIP:       seesaw.ParseIP("1.1.1.1"),
-		backendIP:       seesaw.ParseIP("1.1.1.2"),
-		servicePort:     80,
-		serviceProtocol: 6,
-		healthcheckType: seesaw.HCTypeTCP,
-		healthcheckPort: 81,
-		name:            "TCP/81_0",
+	key3 = CheckKey{
+		VserverIP:       seesaw.ParseIP("1.1.1.1"),
+		BackendIP:       seesaw.ParseIP("1.1.1.2"),
+		ServicePort:     80,
+		ServiceProtocol: 6,
+		HealthcheckType: seesaw.HCTypeTCP,
+		HealthcheckPort: 81,
+		Name:            "TCP/81_0",
 	}
 
-	key4 = checkKey{
-		vserverIP:       seesaw.ParseIP("2012::cafe"),
-		backendIP:       seesaw.ParseIP("2012::cafd"),
-		servicePort:     80,
-		serviceProtocol: 6,
-		healthcheckType: seesaw.HCTypeTCP,
-		healthcheckPort: 81,
-		name:            "TCP/81_0",
+	key4 = CheckKey{
+		VserverIP:       seesaw.ParseIP("2012::cafe"),
+		BackendIP:       seesaw.ParseIP("2012::cafd"),
+		ServicePort:     80,
+		ServiceProtocol: 6,
+		HealthcheckType: seesaw.HCTypeTCP,
+		HealthcheckPort: 81,
+		Name:            "TCP/81_0",
 	}
 )
 
 var hcTests = []struct {
 	desc   string
 	in     *config.Cluster
-	expect map[checkKey]*healthcheck.Config
+	expect map[CheckKey]*healthcheck.Config
 }{
 	{
 		"Empty",
 		&config.Cluster{},
-		make(map[checkKey]*healthcheck.Config),
+		make(map[CheckKey]*healthcheck.Config),
 	},
 	{
 		"One Vserver HC, 1 VserverEntry HC, 1 enabled backend, 1 disabled backend",
@@ -141,7 +141,7 @@ var hcTests = []struct {
 				},
 			},
 		},
-		map[checkKey]*healthcheck.Config{
+		map[CheckKey]*healthcheck.Config{
 			key1: {
 				Interval: 100 * time.Second,
 				Timeout:  50 * time.Second,
@@ -214,15 +214,15 @@ var hcTests = []struct {
 	},
 }
 
-func joinMaps(m1 map[checkKey]healthcheck.Id, m2 map[healthcheck.Id]*healthcheck.Config) map[checkKey]*healthcheck.Config {
-	m3 := make(map[checkKey]*healthcheck.Config)
+func joinMaps(m1 map[CheckKey]healthcheck.Id, m2 map[healthcheck.Id]*healthcheck.Config) map[CheckKey]*healthcheck.Config {
+	m3 := make(map[CheckKey]*healthcheck.Config)
 	for k, id := range m1 {
 		m3[k] = m2[id]
 	}
 	return m3
 }
 
-func clearIDs(m map[checkKey]*healthcheck.Config) {
+func clearIDs(m map[CheckKey]*healthcheck.Config) {
 	for _, v := range m {
 		v.Id = 0
 	}
@@ -300,7 +300,7 @@ func TestHealthchecks(t *testing.T) {
 }
 
 var (
-	hcUpdateCheckKey1 = checkKey{
+	hcUpdateCheckKey1 = CheckKey{
 		seesaw.ParseIP("192.168.36.1"),
 		seesaw.ParseIP("192.168.37.2"),
 		53,
@@ -310,7 +310,7 @@ var (
 		53,
 		"HTTP/53_0",
 	}
-	hcUpdateCheckKey2 = checkKey{
+	hcUpdateCheckKey2 = CheckKey{
 		seesaw.ParseIP("192.168.36.1"),
 		seesaw.ParseIP("192.168.37.3"),
 		53,
@@ -320,7 +320,7 @@ var (
 		53,
 		"HTTP/53_0",
 	}
-	hcUpdateCheckKey3 = checkKey{
+	hcUpdateCheckKey3 = CheckKey{
 		seesaw.ParseIP("192.168.36.1"),
 		seesaw.ParseIP("192.168.37.2"),
 		53,
@@ -330,7 +330,7 @@ var (
 		16767,
 		"HTTP/16767_0",
 	}
-	hcUpdateCheckKey4 = checkKey{
+	hcUpdateCheckKey4 = CheckKey{
 		seesaw.ParseIP("192.168.36.1"),
 		seesaw.ParseIP("192.168.37.3"),
 		53,
@@ -379,11 +379,11 @@ var (
 
 var hcUpdateTests = []struct {
 	desc   string
-	checks map[checkKey]*check
+	checks map[CheckKey]*check
 }{
 	{
 		"initial healthchecks",
-		map[checkKey]*check{
+		map[CheckKey]*check{
 			hcUpdateCheckKey1: {
 				healthcheck: &hcUpdateHealthcheck1,
 			},
@@ -394,7 +394,7 @@ var hcUpdateTests = []struct {
 	},
 	{
 		"change of healthcheck type/port",
-		map[checkKey]*check{
+		map[CheckKey]*check{
 			hcUpdateCheckKey3: {
 				healthcheck: &hcUpdateHealthcheck2,
 			},
@@ -405,7 +405,7 @@ var hcUpdateTests = []struct {
 	},
 	{
 		"change to healthcheck configuration",
-		map[checkKey]*check{
+		map[CheckKey]*check{
 			hcUpdateCheckKey3: {
 				healthcheck: &hcUpdateHealthcheck3,
 			},
@@ -416,7 +416,7 @@ var hcUpdateTests = []struct {
 	},
 	{
 		"remove healthchecks",
-		map[checkKey]*check{},
+		map[CheckKey]*check{},
 	},
 }
 

--- a/engine/sync.go
+++ b/engine/sync.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/google/seesaw/common/seesaw"
 	"github.com/google/seesaw/engine/config"
-	"github.com/google/seesaw/healthcheck"
 
 	log "github.com/golang/glog"
 )
@@ -82,7 +81,7 @@ type SyncNote struct {
 	Type SyncNoteType
 
 	Config      *config.Notification
-	Healthcheck *healthcheck.Notification
+	Healthcheck *SyncHealthCheckNotification
 
 	BackendOverride     *seesaw.BackendOverride
 	DestinationOverride *seesaw.DestinationOverride
@@ -520,7 +519,11 @@ func (sc *syncClient) handleConfigUpdate(sn *SyncNote) {
 // handleHealthcheck handles a healthcheck notification.
 func (sc *syncClient) handleHealthcheck(sn *SyncNote) {
 	log.V(1).Infoln("Sync client received healthcheck notification")
-	// TODO(jsing): Implement.
+	if sn.Healthcheck == nil {
+		log.Errorf("Healthcheck is nil: %v", sn)
+		return
+	}
+	sc.engine.hcManager.handleSyncNote(sn.Healthcheck)
 }
 
 // handleOverride handles an override notification.

--- a/engine/vserver.go
+++ b/engine/vserver.go
@@ -43,7 +43,7 @@ type vserver struct {
 
 	fwm        map[seesaw.AF]uint32
 	services   map[serviceKey]*service
-	checks     map[checkKey]*check
+	checks     map[CheckKey]*check
 	active     map[seesaw.IP]bool
 	lbVservers map[seesaw.IP]*seesaw.Vserver // vservers with configured iptables rules
 	vips       map[seesaw.VIP]bool           // unicast VIPs
@@ -219,43 +219,43 @@ func (d *destination) name() string {
 	return fmt.Sprintf("%v/%v", d.service.vserver.String(), d.String())
 }
 
-// checkKey provides a unique key for a check.
-type checkKey struct {
-	vserverIP       seesaw.IP
-	backendIP       seesaw.IP
-	servicePort     uint16
-	serviceProtocol seesaw.IPProto
-	healthcheckMode seesaw.HealthcheckMode
-	healthcheckType seesaw.HealthcheckType
-	healthcheckPort uint16
-	name            string
+// CheckKey provides a unique key for a check.
+type CheckKey struct {
+	VserverIP       seesaw.IP
+	BackendIP       seesaw.IP
+	ServicePort     uint16
+	ServiceProtocol seesaw.IPProto
+	HealthcheckMode seesaw.HealthcheckMode
+	HealthcheckType seesaw.HealthcheckType
+	HealthcheckPort uint16
+	Name            string
 }
 
-// newCheckKey returns an initialised checkKey.
-func newCheckKey(vip, bip seesaw.IP, port uint16, proto seesaw.IPProto, h *config.Healthcheck) checkKey {
-	return checkKey{
-		vserverIP:       vip,
-		backendIP:       bip,
-		servicePort:     port,
-		serviceProtocol: proto,
-		healthcheckMode: h.Mode,
-		healthcheckType: h.Type,
-		healthcheckPort: h.Port,
-		name:            h.Name,
+// newCheckKey returns an initialised CheckKey.
+func newCheckKey(vip, bip seesaw.IP, port uint16, proto seesaw.IPProto, h *config.Healthcheck) CheckKey {
+	return CheckKey{
+		VserverIP:       vip,
+		BackendIP:       bip,
+		ServicePort:     port,
+		ServiceProtocol: proto,
+		HealthcheckMode: h.Mode,
+		HealthcheckType: h.Type,
+		HealthcheckPort: h.Port,
+		Name:            h.Name,
 	}
 }
 
-// String returns the string representation of a checkKey.
-func (c checkKey) String() string {
+// String returns the string representation of a CheckKey.
+func (c CheckKey) String() string {
 	return fmt.Sprintf("%v:%d/%v backend %v:%d/%v %v %v port %d (%s)",
-		c.vserverIP, c.servicePort, c.serviceProtocol,
-		c.backendIP, c.servicePort, c.serviceProtocol,
-		c.healthcheckMode, c.healthcheckType, c.healthcheckPort, c.name)
+		c.VserverIP, c.ServicePort, c.ServiceProtocol,
+		c.BackendIP, c.ServicePort, c.ServiceProtocol,
+		c.HealthcheckMode, c.HealthcheckType, c.HealthcheckPort, c.Name)
 }
 
 // check contains the running state for a healthcheck.
 type check struct {
-	key         checkKey
+	key         CheckKey
 	vserver     *vserver
 	dests       []*destination
 	healthcheck *config.Healthcheck
@@ -264,7 +264,7 @@ type check struct {
 }
 
 // newCheck returns an initialised check.
-func newCheck(key checkKey, v *vserver, h *config.Healthcheck) *check {
+func newCheck(key CheckKey, v *vserver, h *config.Healthcheck) *check {
 	return &check{
 		key:         key,
 		vserver:     v,
@@ -274,7 +274,7 @@ func newCheck(key checkKey, v *vserver, h *config.Healthcheck) *check {
 
 // checkNotification represents a healthcheck status update.
 type checkNotification struct {
-	key         checkKey
+	key         CheckKey
 	description string
 	status      healthcheck.Status
 }
@@ -282,7 +282,7 @@ type checkNotification struct {
 // vserverChecks represents the current set of healthchecks for a vserver.
 type vserverChecks struct {
 	vserverName string
-	checks      map[checkKey]*check
+	checks      map[CheckKey]*check
 }
 
 // expandServices returns a list of services that have been expanded from the
@@ -402,8 +402,8 @@ func (v *vserver) expandDests(svc *service) map[destinationKey]*destination {
 
 // expandChecks returns a list of checks that have been expanded from the
 // vserver configuration.
-func (v *vserver) expandChecks() map[checkKey]*check {
-	checks := make(map[checkKey]*check)
+func (v *vserver) expandChecks() map[CheckKey]*check {
+	checks := make(map[CheckKey]*check)
 	for _, svc := range v.services {
 		for _, dest := range svc.dests {
 			dest.checks = make([]*check, 0)


### PR DESCRIPTION
backup doesn't do healthcheck which causes a delay during failover. A
successful healthcheck has to be done before backup is able to server
traffic.

This change implemented healthcheck sync so that backup has the fresh
backend status.