### PR TITLE
engine/config: break loop, not switch

### DIFF
--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -324,6 +324,7 @@ func addNodes(c *Cluster, p *pb.Cluster) {
 		nodes = append(nodes, n)
 	}
 	sort.Sort(seesaw.NodesByIPv4{nodes})
+nodesLoop:
 	for i, n := range nodes {
 		switch i {
 		case 0:
@@ -331,7 +332,7 @@ func addNodes(c *Cluster, p *pb.Cluster) {
 		case 1:
 			n.Priority = 1
 		default:
-			break
+			break nodesLoop
 		}
 	}
 }

--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -324,16 +324,12 @@ func addNodes(c *Cluster, p *pb.Cluster) {
 		nodes = append(nodes, n)
 	}
 	sort.Sort(seesaw.NodesByIPv4{nodes})
-nodesLoop:
 	for i, n := range nodes {
-		switch i {
-		case 0:
+		if i == 0 {
 			n.Priority = 255
-		case 1:
-			n.Priority = 1
-		default:
-			break nodesLoop
+			continue
 		}
+		n.Priority = len(nodes)-i
 	}
 }
 


### PR DESCRIPTION
This break statement was breaking the switch at the end of a case, which has no effect.
The loop assigns priority values to the first two nodes, and does nothing to any remaining nodes. Therefore it may as well break the loop and not just the switch.