### PR TITLE
ha: shorten `for _ = range` to `for range`

### DIFF
--- a/ha/core.go
+++ b/ha/core.go
@@ -405,7 +405,7 @@ func (n *Node) receiveAdvertisements() {
 }
 
 func (n *Node) reportStatus() {
-	for _ = range time.Tick(n.StatusReportInterval) {
+	for range time.Tick(n.StatusReportInterval) {
 		var err error
 		failover := false
 		failures := 0
@@ -426,7 +426,7 @@ func (n *Node) reportStatus() {
 }
 
 func (n *Node) checkConfig() {
-	for _ = range time.Tick(n.ConfigCheckInterval) {
+	for range time.Tick(n.ConfigCheckInterval) {
 		failures := 0
 		var cfg *seesaw.HAConfig
 		var err error


### PR DESCRIPTION
`for range` has been acceptable syntax for many Go releases now.