### PR TITLE
ncc/iptables.go: properly type iptAction consts

### DIFF
--- a/ncc/iptables.go
+++ b/ncc/iptables.go
@@ -52,9 +52,9 @@ const (
 	ipt6Cmd = "/sbin/ip6tables"
 
 	iptAppend iptAction = "-A"
-	iptCheck            = "-C"
-	iptDelete           = "-D"
-	iptInsert           = "-I"
+	iptCheck iptAction  = "-C"
+	iptDelete iptAction = "-D"
+	iptInsert iptAction = "-I"
 
 	iptMaxTries      = 5
 	iptResourceError = 4


### PR DESCRIPTION
In this const block, where the expression is not omitted, implicit repetition does not apply, so the consts aren't of iptAction type. The type must be specified.