### PR TITLE
Avoid seesaw_ha crashing when processing large amount of services

### DIFF
--- a/binaries/seesaw_ha/main.go
+++ b/binaries/seesaw_ha/main.go
@@ -57,7 +57,7 @@ var (
 	statusReportMaxFailures = flag.Int("status_report_max_failures", 3,
 		"The maximum allowable number of consecutive status report failures")
 
-	statusReportRetryDelay = flag.Duration("status_report_retry_delay", 2*time.Second,
+	statusReportRetryDelay = flag.Duration("status_report_retry_delay", 10*time.Second,
 		"Time between status report retries")
 
 	testLocalAddr = flag.String("local_addr", "",

--- a/engine/core.go
+++ b/engine/core.go
@@ -161,13 +161,23 @@ func (e *Engine) queueOverride(o seesaw.Override) {
 }
 
 // setHAState tells the engine what its current HAState should be.
-func (e *Engine) setHAState(state seesaw.HAState) {
-	e.haManager.stateChan <- state
+func (e *Engine) setHAState(state seesaw.HAState) error {
+	select {
+	case e.haManager.stateChan <- state:
+	default:
+		return fmt.Errorf("state channel if full")
+	}
+	return nil
 }
 
 // setHAStatus tells the engine what the current HA status is.
-func (e *Engine) setHAStatus(status seesaw.HAStatus) {
-	e.haManager.statusChan <- status
+func (e *Engine) setHAStatus(status seesaw.HAStatus) error {
+	select {
+	case e.haManager.statusChan <- status:
+	default:
+		return fmt.Errorf("status channel if full")
+	}
+	return nil
 }
 
 // haConfig returns the HAConfig for an engine.
@@ -331,10 +341,12 @@ func (e *Engine) gratuitousARP() {
 			if err := e.ncc.Dial(); err != nil {
 				log.Fatalf("Failed to connect to NCC: %v", err)
 			}
-			defer e.ncc.Close()
+
 			if err := e.ncc.ARPSendGratuitous(e.config.LBInterface, e.config.ClusterVIP.IPv4Addr); err != nil {
+				e.ncc.Close()
 				log.Fatalf("Failed to send gratuitous ARP: %v", err)
 			}
+			e.ncc.Close()
 
 		case <-e.shutdownARP:
 			e.shutdownARP <- true
@@ -347,10 +359,29 @@ func (e *Engine) gratuitousARP() {
 // seesaw engine.
 func (e *Engine) manager() {
 	for {
+		// process ha state updates first before processing others
 		select {
+		case state := <-e.haManager.stateChan:
+			log.Infof("Received HA state notification %v", state)
+			e.haManager.setState(state)
+			continue
+		case status := <-e.haManager.statusChan:
+			log.V(1).Infof("Received HA status notification (%v)", status.State)
+			e.haManager.setStatus(status)
+			continue
+		default:
+		}
+		select {
+		case state := <-e.haManager.stateChan:
+			log.Infof("Received HA state notification %v", state)
+			e.haManager.setState(state)
+
+		case status := <-e.haManager.statusChan:
+			log.V(1).Infof("Received HA status notification (%v)", status.State)
+			e.haManager.setStatus(status)
+
 		case n := <-e.notifier.C:
 			log.Infof("Received cluster config notification; %v", &n)
-
 			e.syncServer.notify(&SyncNote{Type: SNTConfigUpdate})
 
 			e.clusterLock.Lock()
@@ -386,14 +417,6 @@ func (e *Engine) manager() {
 
 			// TODO(jsing): Ensure this does not block.
 			e.updateVservers()
-
-		case state := <-e.haManager.stateChan:
-			log.Infof("Received HA state notification %v", state)
-			e.haManager.setState(state)
-
-		case status := <-e.haManager.statusChan:
-			log.Infof("Received HA status notification (%v)", status.State)
-			e.haManager.setStatus(status)
 
 		case <-e.haManager.timer():
 			log.Infof("Timed out waiting for HAState")
@@ -598,7 +621,6 @@ func (e *Engine) becomeMaster() {
 		log.Fatalf("Failed to connect to NCC: %v", err)
 	}
 	defer e.ncc.Close()
-
 	e.syncClient.disable()
 	e.hcManager.enable()
 	e.notifier.SetSource(config.SourceServer)

--- a/engine/ipc.go
+++ b/engine/ipc.go
@@ -100,7 +100,9 @@ func (s *SeesawEngine) HAUpdate(args *ipc.HAStatus, failover *bool) error {
 		return errors.New("insufficient access")
 	}
 
-	s.engine.setHAStatus(args.Status)
+	if err := s.engine.setHAStatus(args.Status); err != nil {
+		return err
+	}
 	if failover != nil {
 		*failover = s.engine.haManager.failover()
 	}
@@ -123,8 +125,7 @@ func (s *SeesawEngine) HAState(args *ipc.HAState, reply *int) error {
 		return errors.New("insufficient access")
 	}
 
-	s.engine.setHAState(args.State)
-	return nil
+	return s.engine.setHAState(args.State)
 }
 
 // HAStatus returns the current HA status from the Seesaw Engine.


### PR DESCRIPTION
    When there are large number of services, it takes minutes for the engine
    main  goroutine to process the config. seesaw_ha will failed to push ha
    update to the engine and goes into a crash loop.

    This change make seesaw_ha wait longer and have the seesaw_engine main
    goroutine process ha state at a higher priority.