### PR TITLE
Dedup healthchecks

### DIFF
--- a/engine/healthcheck_test.go
+++ b/engine/healthcheck_test.go
@@ -30,21 +30,34 @@ import (
 )
 
 var (
+	healthchecks = map[string]*config.Healthcheck{
+		"TCP/81": {
+			Type:     seesaw.HCTypeTCP,
+			Port:     81,
+			Interval: 100 * time.Second,
+			Timeout:  50 * time.Second,
+			Send:     "some tcp request",
+			Receive:  "some tcp response",
+			Name:     "TCP/81",
+		},
+		"HTTP/3901": {
+			Type:     seesaw.HCTypeHTTP,
+			Port:     3901,
+			Interval: 100 * time.Second,
+			Timeout:  50 * time.Second,
+			Send:     "some request",
+			Receive:  "some response",
+			Code:     200,
+			Name:     "HTTP/3901",
+		},
+	}
 	hcTestEntries = map[string]*config.VserverEntry{
 		"80/TCP": {
 			Port:  80,
 			Proto: seesaw.IPProtoTCP,
 			Mode:  seesaw.LBModeDSR,
 			Healthchecks: map[string]*config.Healthcheck{
-				"TCP/81": {
-					Type:     seesaw.HCTypeTCP,
-					Port:     81,
-					Interval: 100 * time.Second,
-					Timeout:  50 * time.Second,
-					Send:     "some tcp request",
-					Receive:  "some tcp response",
-					Name:     "TCP/81_0",
-				},
+				"TCP/81": healthchecks["TCP/81"],
 			},
 		},
 	}
@@ -63,64 +76,55 @@ var (
 	}
 
 	hcTestHealthchecks = map[string]*config.Healthcheck{
-		"HTTP/3901": {
-			Type:     seesaw.HCTypeHTTP,
-			Port:     3901,
-			Interval: 100 * time.Second,
-			Timeout:  50 * time.Second,
-			Send:     "some request",
-			Receive:  "some response",
-			Code:     200,
-			Name:     "HTTP/3901_0",
+		"HTTP/3901": healthchecks["HTTP/3901"],
+	}
+
+	key1 = checkerKey{
+		key: CheckKey{
+			BackendIP:       seesaw.ParseIP("1.1.1.2"),
+			HealthcheckType: seesaw.HCTypeHTTP,
+			HealthcheckPort: 3901,
 		},
+		cfg: *healthchecks["HTTP/3901"],
 	}
 
-	key1 = CheckKey{
-		VserverIP:       seesaw.ParseIP("1.1.1.1"),
-		BackendIP:       seesaw.ParseIP("1.1.1.2"),
-		HealthcheckType: seesaw.HCTypeHTTP,
-		HealthcheckPort: 3901,
-		Name:            "HTTP/3901_0",
+	key2 = checkerKey{
+		key: CheckKey{
+			BackendIP:       seesaw.ParseIP("2012::cafd"),
+			HealthcheckType: seesaw.HCTypeHTTP,
+			HealthcheckPort: 3901,
+		},
+		cfg: *healthchecks["HTTP/3901"],
 	}
 
-	key2 = CheckKey{
-		VserverIP:       seesaw.ParseIP("2012::cafe"),
-		BackendIP:       seesaw.ParseIP("2012::cafd"),
-		HealthcheckType: seesaw.HCTypeHTTP,
-		HealthcheckPort: 3901,
-		Name:            "HTTP/3901_0",
+	key3 = checkerKey{
+		key: CheckKey{
+			BackendIP:       seesaw.ParseIP("1.1.1.2"),
+			HealthcheckType: seesaw.HCTypeTCP,
+			HealthcheckPort: 81,
+		},
+		cfg: *healthchecks["TCP/81"],
 	}
 
-	key3 = CheckKey{
-		VserverIP:       seesaw.ParseIP("1.1.1.1"),
-		BackendIP:       seesaw.ParseIP("1.1.1.2"),
-		ServicePort:     80,
-		ServiceProtocol: 6,
-		HealthcheckType: seesaw.HCTypeTCP,
-		HealthcheckPort: 81,
-		Name:            "TCP/81_0",
-	}
-
-	key4 = CheckKey{
-		VserverIP:       seesaw.ParseIP("2012::cafe"),
-		BackendIP:       seesaw.ParseIP("2012::cafd"),
-		ServicePort:     80,
-		ServiceProtocol: 6,
-		HealthcheckType: seesaw.HCTypeTCP,
-		HealthcheckPort: 81,
-		Name:            "TCP/81_0",
+	key4 = checkerKey{
+		key: CheckKey{
+			BackendIP:       seesaw.ParseIP("2012::cafd"),
+			HealthcheckType: seesaw.HCTypeTCP,
+			HealthcheckPort: 81,
+		},
+		cfg: *healthchecks["TCP/81"],
 	}
 )
 
 var hcTests = []struct {
 	desc   string
 	in     *config.Cluster
-	expect map[CheckKey]*healthcheck.Config
+	expect map[checkerKey]*healthcheck.Config
 }{
 	{
 		"Empty",
 		&config.Cluster{},
-		make(map[CheckKey]*healthcheck.Config),
+		make(map[checkerKey]*healthcheck.Config),
 	},
 	{
 		"One Vserver HC, 1 VserverEntry HC, 1 enabled backend, 1 disabled backend",
@@ -141,7 +145,7 @@ var hcTests = []struct {
 				},
 			},
 		},
-		map[CheckKey]*healthcheck.Config{
+		map[checkerKey]*healthcheck.Config{
 			key1: {
 				Interval: 100 * time.Second,
 				Timeout:  50 * time.Second,
@@ -214,15 +218,15 @@ var hcTests = []struct {
 	},
 }
 
-func joinMaps(m1 map[CheckKey]healthcheck.Id, m2 map[healthcheck.Id]*healthcheck.Config) map[CheckKey]*healthcheck.Config {
-	m3 := make(map[CheckKey]*healthcheck.Config)
+func joinMaps(m1 map[checkerKey]healthcheck.Id, m2 map[healthcheck.Id]*healthcheck.Config) map[checkerKey]*healthcheck.Config {
+	m3 := make(map[checkerKey]*healthcheck.Config)
 	for k, id := range m1 {
 		m3[k] = m2[id]
 	}
 	return m3
 }
 
-func clearIDs(m map[CheckKey]*healthcheck.Config) {
+func clearIDs(m map[checkerKey]*healthcheck.Config) {
 	for _, v := range m {
 		v.Id = 0
 	}
@@ -268,7 +272,7 @@ func TestHealthchecks(t *testing.T) {
 		clearIDs(got)
 
 		if !reflect.DeepEqual(test.expect, got) {
-			t.Errorf("TestHealthchecks failed for %q (#%d), want %#v, got %#v",
+			t.Errorf("TestHealthchecks failed for %q (#%d), \nwant %#v, \ngot %#v",
 				test.desc, i, test.expect, got)
 			for k, v := range test.expect {
 				if !reflect.DeepEqual(v, got[k]) {
@@ -340,6 +344,16 @@ var (
 		16767,
 		"HTTP/16767_0",
 	}
+	hcUpdateCheckKey5 = CheckKey{
+		seesaw.ParseIP("192.168.36.2"),
+		seesaw.ParseIP("192.168.37.2"),
+		53,
+		seesaw.IPProtoUDP,
+		seesaw.HCModePlain,
+		seesaw.HCTypeHTTPS,
+		16767,
+		"HTTP/16767_0",
+	}
 
 	hcUpdateHealthcheck1 = config.Healthcheck{
 		Name:      "DNS/53_0",
@@ -377,13 +391,21 @@ var (
 	}
 )
 
+func makeCheckerKey(key CheckKey, cfg *config.Healthcheck) checkerKey {
+	return checkerKey{
+		key: dedup(key),
+		cfg: *cfg,
+	}
+}
+
 var hcUpdateTests = []struct {
-	desc   string
-	checks map[CheckKey]*check
+	desc     string
+	checks   map[CheckKey]*check
+	expected []checkerKey
 }{
 	{
-		"initial healthchecks",
-		map[CheckKey]*check{
+		desc: "initial healthchecks",
+		checks: map[CheckKey]*check{
 			hcUpdateCheckKey1: {
 				healthcheck: &hcUpdateHealthcheck1,
 			},
@@ -391,10 +413,14 @@ var hcUpdateTests = []struct {
 				healthcheck: &hcUpdateHealthcheck1,
 			},
 		},
+		expected: []checkerKey{
+			makeCheckerKey(hcUpdateCheckKey1, &hcUpdateHealthcheck1),
+			makeCheckerKey(hcUpdateCheckKey2, &hcUpdateHealthcheck1),
+		},
 	},
 	{
-		"change of healthcheck type/port",
-		map[CheckKey]*check{
+		desc: "change of healthcheck type/port",
+		checks: map[CheckKey]*check{
 			hcUpdateCheckKey3: {
 				healthcheck: &hcUpdateHealthcheck2,
 			},
@@ -402,10 +428,14 @@ var hcUpdateTests = []struct {
 				healthcheck: &hcUpdateHealthcheck2,
 			},
 		},
+		expected: []checkerKey{
+			makeCheckerKey(hcUpdateCheckKey3, &hcUpdateHealthcheck2),
+			makeCheckerKey(hcUpdateCheckKey4, &hcUpdateHealthcheck2),
+		},
 	},
 	{
-		"change to healthcheck configuration",
-		map[CheckKey]*check{
+		desc: "change to healthcheck configuration",
+		checks: map[CheckKey]*check{
 			hcUpdateCheckKey3: {
 				healthcheck: &hcUpdateHealthcheck3,
 			},
@@ -413,10 +443,33 @@ var hcUpdateTests = []struct {
 				healthcheck: &hcUpdateHealthcheck3,
 			},
 		},
+		expected: []checkerKey{
+			makeCheckerKey(hcUpdateCheckKey3, &hcUpdateHealthcheck3),
+			makeCheckerKey(hcUpdateCheckKey4, &hcUpdateHealthcheck3),
+		},
 	},
 	{
-		"remove healthchecks",
-		map[CheckKey]*check{},
+		desc: "healthcheck dedup",
+		checks: map[CheckKey]*check{
+			hcUpdateCheckKey3: {
+				healthcheck: &hcUpdateHealthcheck3,
+			},
+			hcUpdateCheckKey4: {
+				healthcheck: &hcUpdateHealthcheck3,
+			},
+			hcUpdateCheckKey5: {
+				healthcheck: &hcUpdateHealthcheck3,
+			},
+		},
+		expected: []checkerKey{
+			makeCheckerKey(hcUpdateCheckKey3, &hcUpdateHealthcheck3),
+			makeCheckerKey(hcUpdateCheckKey4, &hcUpdateHealthcheck3),
+		},
+	},
+
+	{
+		desc:   "remove healthchecks",
+		checks: map[CheckKey]*check{},
 	},
 }
 
@@ -427,34 +480,38 @@ func TestHealthcheckUpdates(t *testing.T) {
 		hcm.update("test", test.checks)
 
 		// Basic sanity checks...
-		if len(hcm.ids) != len(test.checks) {
-			t.Errorf("%q: got %d IDs, want %d", test.desc, len(hcm.ids), len(test.checks))
+		if len(hcm.ids) != len(test.expected) {
+			t.Errorf("%q: got %d IDs, want %d", test.desc, len(hcm.ids), len(test.expected))
 			continue
 		}
-		if len(hcm.cfgs) != len(test.checks) {
-			t.Errorf("%q: got %d configs, want %d", test.desc, len(hcm.cfgs), len(test.checks))
+		if len(hcm.cfgs) != len(test.expected) {
+			t.Errorf("%q: got %d configs, want %d", test.desc, len(hcm.cfgs), len(test.expected))
 			continue
 		}
-		if len(hcm.checks) != len(test.checks) {
-			t.Errorf("%q: got %d checks, want %d", test.desc, len(hcm.checks), len(test.checks))
+		if len(hcm.checks) != len(test.expected) {
+			t.Errorf("%q: got %d checks, want %d", test.desc, len(hcm.checks), len(test.expected))
 			continue
 		}
 
 		// Find the healthcheck ID and compare the configuration.
-		for key, check := range test.checks {
+		for _, key := range test.expected {
 			id, ok := hcm.ids[key]
 			if !ok {
 				t.Errorf("%q: failed to find ID for key %#v", test.desc, key)
 				continue
 			}
-			hc, ok := hcm.checks[id]
+			hcList, ok := hcm.checks[id]
 			if !ok {
 				t.Errorf("%q: failed to find check for key %#v via ID %d", test.desc, key, id)
 				continue
 			}
-			if *hc.healthcheck != *check.healthcheck {
-				t.Errorf("%q: got healthcheck %#+v, want %#+v", test.desc, *hc.healthcheck, *check.healthcheck)
+
+			for _, hc := range hcList {
+				if *hc.healthcheck != key.cfg {
+					t.Errorf("%q: got healthcheck config %#+v, want %#+v", test.desc, *hc.healthcheck, key.cfg)
+				}
 			}
+
 		}
 	}
 }

--- a/engine/ipc.go
+++ b/engine/ipc.go
@@ -180,7 +180,7 @@ func (s *SeesawEngine) HealthState(args *healthcheck.HealthState, reply *int) er
 	}
 
 	for _, n := range args.Notifications {
-		if err := s.engine.hcManager.healthState(n); err != nil {
+		if err := s.engine.hcManager.queueHealthState(n); err != nil {
 			return err
 		}
 	}

--- a/engine/sync.go
+++ b/engine/sync.go
@@ -519,11 +519,6 @@ func (sc *syncClient) handleConfigUpdate(sn *SyncNote) {
 // handleHealthcheck handles a healthcheck notification.
 func (sc *syncClient) handleHealthcheck(sn *SyncNote) {
 	log.V(1).Infoln("Sync client received healthcheck notification")
-	if sn.Healthcheck == nil {
-		log.Errorf("Healthcheck is nil: %v", sn)
-		return
-	}
-	sc.engine.hcManager.handleSyncNote(sn.Healthcheck)
 }
 
 // handleOverride handles an override notification.

--- a/healthcheck/http.go
+++ b/healthcheck/http.go
@@ -89,7 +89,6 @@ func (hc *HTTPChecker) Check(timeout time.Duration) *Result {
 	if timeout == time.Duration(0) {
 		timeout = defaultHTTPTimeout
 	}
-	deadline := start.Add(timeout)
 
 	u, err := url.Parse(hc.Request)
 	if err != nil {
@@ -109,14 +108,19 @@ func (hc *HTTPChecker) Check(timeout time.Duration) *Result {
 		proxy = http.ProxyURL(u)
 	}
 
-	conn, err := dialTCP(hc.network(), hc.addr(), timeout, hc.Mark)
-	if err != nil {
-		return complete(start, "", false, err)
-	}
-	defer conn.Close()
+	var dialer func(network, addr string) (net.Conn, error)
 
-	dialer := func(net string, addr string) (net.Conn, error) {
-		return conn, nil
+	// DSR mode requires socket marks
+	if hc.Mode == seesaw.HCModeDSR {
+		conn, err := dialTCP(hc.network(), hc.addr(), timeout, hc.Mark)
+		if err != nil {
+			return complete(start, "", false, err)
+		}
+		defer conn.Close()
+
+		dialer = func(net string, addr string) (net.Conn, error) {
+			return conn, nil
+		}
 	}
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: !hc.TLSVerify,
@@ -130,6 +134,7 @@ func (hc *HTTPChecker) Check(timeout time.Duration) *Result {
 			Proxy:           proxy,
 			TLSClientConfig: tlsConfig,
 		},
+		Timeout: timeout,
 	}
 	req, err := http.NewRequest(hc.Method, hc.Request, nil)
 	req.URL = u
@@ -137,7 +142,6 @@ func (hc *HTTPChecker) Check(timeout time.Duration) *Result {
 	// If we received a response we want to process it, even in the
 	// presence of an error - a redirect 3xx will result in both the
 	// response and an error being returned.
-	conn.SetDeadline(deadline)
 	resp, err := client.Do(req)
 	if resp == nil {
 		return complete(start, "", false, err)


### PR DESCRIPTION
This commit dedups healthchecks when different vservers are using
the same backends.

optimize http healthcheck to use default dailer when not DSR mode.

disable healthcheck sync but enable healthcheck in backup so that during
a failover, backup doesn't need time to ramp healthchecks