### PR TITLE
always enable healthcheck in backup

### DIFF
--- a/engine/core.go
+++ b/engine/core.go
@@ -622,7 +622,6 @@ func (e *Engine) becomeMaster() {
 	}
 	defer e.ncc.Close()
 	e.syncClient.disable()
-	e.hcManager.enable()
 	e.notifier.SetSource(config.SourceServer)
 
 	if err := e.lbInterface.Up(); err != nil {
@@ -639,7 +638,6 @@ func (e *Engine) becomeBackup() {
 	defer e.ncc.Close()
 
 	e.syncClient.enable()
-	e.hcManager.disable()
 	e.notifier.SetSource(config.SourceServer)
 
 	if err := e.lbInterface.Down(); err != nil {


### PR DESCRIPTION
healthcheck was disabled in backup node. This causes service disruption
during failover because it takes a bit while for all healthcheck to come
up if there are large amounts of services.

This commit stops disabling healthcheck on a backup node.