### PR TITLE
watchdog: use time.Time's Format method

### DIFF
--- a/watchdog/service.go
+++ b/watchdog/service.go
@@ -176,8 +176,7 @@ done:
 func (svc *Service) logFile() (*os.File, error) {
 	name := "seesaw_" + svc.name
 	t := time.Now()
-	logName := fmt.Sprintf("%s.log.%04d%02d%02d-%02d%02d%02d", name,
-		t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second())
+	logName := fmt.Sprintf("%s.log.%s", name, t.Format("20060102-150405"))
 
 	f, err := os.Create(path.Join(logDir, logName))
 	if err != nil {


### PR DESCRIPTION
The Format method of time.Time is a simpler way of formatting a timestamp in a particular way, than breaking the components out individually.