### PR TITLE
Exit seesaw_ha quickly after seesaw_engine exits

### DIFF
--- a/binaries/seesaw_engine/main.go
+++ b/binaries/seesaw_engine/main.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/google/seesaw/common/seesaw"
 	"github.com/google/seesaw/common/server"
-	"github.com/google/seesaw/engine/config"
 	"github.com/google/seesaw/engine"
+	"github.com/google/seesaw/engine/config"
 
 	conf "github.com/dlintw/goconf"
 	log "github.com/golang/glog"
@@ -191,6 +191,11 @@ func main() {
 	engineCfg.ServiceAnycastIPv6 = serviceAnycastIPv6
 	engineCfg.SocketPath = *socketPath
 	engineCfg.VRID = vrid
+
+	// removes previous leftover socket.
+	if err := server.RemoveUnixSocket(engineCfg.SocketPath); err != nil {
+		log.Exitf("Failed to remove socket: %v", err)
+	}
 
 	// Gentlemen, start your engines...
 	engine := engine.NewEngine(&engineCfg)

--- a/binaries/seesaw_ha/main.go
+++ b/binaries/seesaw_ha/main.go
@@ -36,7 +36,7 @@ var (
 	configCheckInterval = flag.Duration("config_check_interval", 15*time.Second,
 		"How frequently to poll the engine for HAConfig changes")
 
-	configCheckMaxFailures = flag.Int("config_check_max_failures", 3,
+	configCheckMaxFailures = flag.Int("config_check_max_failures", 15,
 		"The maximum allowable number of consecutive config check failures")
 
 	configCheckRetryDelay = flag.Duration("config_check_retry_delay", 2*time.Second,
@@ -54,10 +54,10 @@ var (
 	statusReportInterval = flag.Duration("status_report_interval", 3*time.Second,
 		"How frequently to report the current HAStatus to the engine")
 
-	statusReportMaxFailures = flag.Int("status_report_max_failures", 3,
+	statusReportMaxFailures = flag.Int("status_report_max_failures", 15,
 		"The maximum allowable number of consecutive status report failures")
 
-	statusReportRetryDelay = flag.Duration("status_report_retry_delay", 10*time.Second,
+	statusReportRetryDelay = flag.Duration("status_report_retry_delay", 2*time.Second,
 		"Time between status report retries")
 
 	testLocalAddr = flag.String("local_addr", "",
@@ -132,7 +132,7 @@ func main() {
 		StatusReportMaxFailures: *statusReportMaxFailures,
 		StatusReportRetryDelay:  *statusReportRetryDelay,
 	}
-	n := ha.NewNode(nc, conn, engine)
+	n := ha.NewNode(nc, conn, engine, *engineSocket)
 	server.ShutdownHandler(n)
 
 	if err = n.Run(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.12
 
 require (
 	github.com/dlintw/goconf v0.0.0-20120228082610-dcc070983490
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.2
 	github.com/kylelemons/godebug v1.1.0
 	github.com/miekg/dns v1.1.27
 	golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876
+	gopkg.in/fsnotify.v1 v1.4.7
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/dlintw/goconf v0.0.0-20120228082610-dcc070983490 h1:I8/Qu5NTaiXi1TsEYmTeLDUlf7u9pEdbG+azjDvx8Vg=
 github.com/dlintw/goconf v0.0.0-20120228082610-dcc070983490/go.mod h1:jWlUIP63OLr0cV2FGN2IEzSFsMAe58if8rk/SAE0JRE=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
@@ -25,6 +27,10 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe h1:6fAMxZRR6sl1Uq8U61gxU+kPTs2tR8uOySCbBP7BN/M=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9 h1:L2auWcuQIvxz9xSEqzESnV/QN/gNRXNApHi3fYwl2w0=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
+gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/ha/ha_test.go
+++ b/ha/ha_test.go
@@ -52,7 +52,7 @@ func newTestNode() *Node {
 		},
 		MasterAdvertInterval: 60 * time.Second,
 	}
-	n := NewNode(nc, haConn, engine)
+	n := NewNode(nc, haConn, engine, "/dev/null")
 	// force runOnce() to timeout immediately
 	n.masterDownInterval = 1
 	return n


### PR DESCRIPTION
seesaw_engine may exits in two cases:
1. seesaw_engine triggers os.Exit. This is common whenever
log.Fatal/Exit is called.
2. SIGTERM is received.

In both cases seesaw_ha may still keep announcing as master
which causes traffic disruption.

This commit fixes this by watching seesaw engine socket file in
seesaw_ha:
1. os.Exit doesn't clean up so engine socket file is not removed. But
all ipvs services keep working until a new seesaw_engine instance wipes
out previous config. So we remove leftover engine socket file first
thing to exit seesaw_ha before wipe out.
2. SIGTERM will be handled gracefully and engine socket is removed
before exiting. seesaw_ha will notice the deletion and exit together.