### PR TITLE
Add --dry_run config to healthceck CLI

### DIFF
--- a/binaries/seesaw_healthcheck/main.go
+++ b/binaries/seesaw_healthcheck/main.go
@@ -54,6 +54,10 @@ var (
 	retryDelay = flag.Duration("retry_delay",
 		healthcheck.DefaultServerConfig().RetryDelay,
 		"The time between notification RPC retries")
+
+	dryRun = flag.Bool("dry_run",
+		healthcheck.DefaultServerConfig().DryRun,
+		"Skips actual check and always return healthy as result")
 )
 
 func main() {
@@ -68,6 +72,7 @@ func main() {
 	cfg.MaxFailures = *maxFailures
 	cfg.NotifyInterval = *notifyInterval
 	cfg.RetryDelay = *retryDelay
+	cfg.DryRun = *dryRun
 
 	hc := healthcheck.NewServer(&cfg)
 	server.ShutdownHandler(hc)

--- a/healthcheck/healthcheck_test.go
+++ b/healthcheck/healthcheck_test.go
@@ -524,3 +524,27 @@ func TestCheckTimeout(t *testing.T) {
 		t.Errorf("Expected state change notification not received")
 	}
 }
+
+func TestCheckDryrun(t *testing.T) {
+	notify := make(chan *Notification, 10)
+	hc := NewCheck(notify)
+	hc.Blocking(true)
+	hc.Dryrun(true)
+	go hc.Run(nil)
+	defer hc.Stop()
+
+	config := NewConfig(1, &fakeChecker{succeed: false})
+	config.Interval = 250 * time.Millisecond
+	hc.Update(config)
+
+	// We should have a notification for StateHealthy
+	select {
+	case n := <-notify:
+		if n.State != StateHealthy {
+			t.Errorf("Unexpected state - got %v, want %v",
+				n.State, StateHealthy)
+		}
+	default:
+		t.Errorf("Expected state change notification not received")
+	}
+}


### PR DESCRIPTION
If turned on, healthcheck server will continue to spin up goroutines for
managed checks, but skip the actual healthcheck execution and always
report success back via notification channel.

This is helpful in integration test scenario where backend server
doesn't really exists or functioning.