### PR TITLE
engine/config: propagate errors in protoToCluster

### DIFF
--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -178,12 +178,22 @@ func protoToCluster(p *pb.Cluster, clusterName string) (*Cluster, error) {
 	c.BGPLocalASN = uint32(p.GetBgpLocalAsn())
 	c.BGPRemoteASN = uint32(p.GetBgpRemoteAsn())
 
-	addBGPPeers(c, p)
+	if err := addBGPPeers(c, p); err != nil {
+		return nil, err
+	}
 	addMetadata(c, p)
-	addNodes(c, p)
-	addVIPSubnets(c, p)
-	addVLANs(c, p)
-	addVservers(c, p)
+	if err := addNodes(c, p); err != nil {
+		return nil, err
+	}
+	if err := addVIPSubnets(c, p); err != nil {
+		return nil, err
+	}
+	if err := addVLANs(c, p); err != nil {
+		return nil, err
+	}
+	if err := addVservers(c, p); err != nil {
+		return nil, err
+	}
 	addWarnings(c, p)
 
 	return c, nil
@@ -274,11 +284,14 @@ func protoToHost(p *pb.Host) seesaw.Host {
 	}
 }
 
-func addBGPPeers(c *Cluster, p *pb.Cluster) {
+func addBGPPeers(c *Cluster, p *pb.Cluster) error {
 	for _, p := range p.BgpPeer {
 		peer := protoToHost(p)
-		c.AddBGPPeer(&peer)
+		if err := c.AddBGPPeer(&peer); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func addMetadata(c *Cluster, p *pb.Cluster) {
@@ -293,7 +306,7 @@ func addMetadata(c *Cluster, p *pb.Cluster) {
 	}
 }
 
-func addNodes(c *Cluster, p *pb.Cluster) {
+func addNodes(c *Cluster, p *pb.Cluster) error {
 	var haEnabled bool
 	switch *p.SeesawVip.Status {
 	case pb.Host_PRODUCTION, pb.Host_TESTING, pb.Host_BUILDING:
@@ -316,7 +329,9 @@ func addNodes(c *Cluster, p *pb.Cluster) {
 			node.BGPEnabled = true
 			node.VserversEnabled = true
 		}
-		c.AddNode(node)
+		if err := c.AddNode(node); err != nil {
+			return err
+		}
 	}
 
 	// Prioritise nodes by their IPv4 addresses.
@@ -335,17 +350,21 @@ func addNodes(c *Cluster, p *pb.Cluster) {
 			break
 		}
 	}
+	return nil
 }
 
-func addVLANs(c *Cluster, p *pb.Cluster) {
+func addVLANs(c *Cluster, p *pb.Cluster) error {
 	for _, v := range p.Vlan {
 		h := protoToHost(v.Host)
-		c.AddVLAN(&seesaw.VLAN{
+		vlan := &seesaw.VLAN{
 			ID:           uint16(*v.VlanId),
 			Host:         h,
 			BackendCount: make(map[seesaw.AF]uint),
 			VIPCount:     make(map[seesaw.AF]uint),
-		})
+		}
+		if err := c.AddVLAN(vlan); err != nil {
+			return err
+		}
 	}
 
 	// Determine number of backend and VIP addresses in each VLAN.
@@ -387,22 +406,25 @@ func addVLANs(c *Cluster, p *pb.Cluster) {
 			}
 		}
 	}
+	return nil
 }
 
-func addVIPSubnets(c *Cluster, p *pb.Cluster) {
+func addVIPSubnets(c *Cluster, p *pb.Cluster) error {
 	for _, cidr := range p.DedicatedVipSubnet {
 		_, vipSubnet, err := net.ParseCIDR(cidr)
 		if err != nil {
-			log.Errorf("%v: Unable to parse VIP subnet %v: %v", c.Site, cidr, err)
-			continue
+			return fmt.Errorf("%v: unable to parse VIP subnet %v: %v", c.Site, cidr, err)
 		}
 		if err := c.AddVIPSubnet(vipSubnet); err != nil {
-			log.Errorf("%v: Unable to add VIP subnet %v: %v", c.Site, cidr, err)
+			return err
 		}
 	}
+	return nil
 }
 
-func addVservers(c *Cluster, p *pb.Cluster) {
+func addVservers(c *Cluster, p *pb.Cluster) error {
+	// TODO: Decide whether to mark VServers with invalid config as broken in
+	// some way, or to propagate the error.
 	for _, vs := range p.Vserver {
 		host := vs.GetEntryAddress()
 		v := NewVserver(vs.GetName(), protoToHost(host))
@@ -412,8 +434,11 @@ func addVservers(c *Cluster, p *pb.Cluster) {
 		sort.Strings(v.Warnings)
 
 		for _, ip := range []net.IP{v.Host.IPv4Addr, v.Host.IPv6Addr} {
-			if ip != nil {
-				v.AddVIP(seesaw.NewVIP(ip, c.VIPSubnets))
+			if ip == nil {
+				continue
+			}
+			if err := v.AddVIP(seesaw.NewVIP(ip, c.VIPSubnets)); err != nil {
+				log.Warningf("Adding VIP: %v", err)
 			}
 		}
 
@@ -502,6 +527,7 @@ func addVservers(c *Cluster, p *pb.Cluster) {
 			log.Warning(err)
 		}
 	}
+	return nil
 }
 
 func addWarnings(c *Cluster, p *pb.Cluster) {

--- a/engine/config/config_test.go
+++ b/engine/config/config_test.go
@@ -210,12 +210,22 @@ var vipSubnetTests = []struct {
 		make(map[string]*net.IPNet),
 	},
 	{
-		"3 Dedicated VIP Subnets, with duplicates",
+		"2 Dedicated VIP Subnets",
 		"vipsubnets1.pb",
 		map[string]*net.IPNet{
 			"192.168.9.0/24":   cidrToNet("192.168.9.0/24"),
 			"2015:cafe:9::/64": cidrToNet("2015:cafe:9::/64"),
 		},
+	},
+}
+
+var vipSubnetFailureTests = []struct {
+	desc string
+	in   string
+}{
+	{
+		"Duplicate Dedicated VIP Subnets",
+		"vipsubnets2.pb",
 	},
 }
 
@@ -595,6 +605,15 @@ func TestVIPSubnets(t *testing.T) {
 			if !reflect.DeepEqual(*vipSubnet, *got[i]) {
 				t.Errorf("Test %q want %#v, got %#v", test.desc, *vipSubnet, *got[i])
 			}
+		}
+	}
+}
+
+func TestVIPSubnetFailures(t *testing.T) {
+	for _, test := range vipSubnetTests {
+		filename := filepath.Join(testDataDir, test.in)
+		if _, err := ReadConfig(filename, ""); err == nil {
+			t.Errorf("ReadConfig successfully loaded protobuf file %s for %q, should have failed", test.in, test.desc)
 		}
 	}
 }

--- a/engine/config/config_test.go
+++ b/engine/config/config_test.go
@@ -610,7 +610,7 @@ func TestVIPSubnets(t *testing.T) {
 }
 
 func TestVIPSubnetFailures(t *testing.T) {
-	for _, test := range vipSubnetTests {
+	for _, test := range vipSubnetFailureTests {
 		filename := filepath.Join(testDataDir, test.in)
 		if _, err := ReadConfig(filename, ""); err == nil {
 			t.Errorf("ReadConfig successfully loaded protobuf file %s for %q, should have failed", test.in, test.desc)

--- a/engine/config/testdata/vipsubnets2.pb
+++ b/engine/config/testdata/vipsubnets2.pb
@@ -3,4 +3,5 @@ seesaw_vip <
   status: PRODUCTION
 >
 dedicated_vip_subnet: "192.168.9.0/24"
+dedicated_vip_subnet: "192.168.9.0/24"
 dedicated_vip_subnet: "2015:cafe:9::/64"


### PR DESCRIPTION
Instead of ignoring or only logging errors when loading configuration, the errors shoud be propagated up and handled.

The question of whether to mark vservers as broken or to propagate the error remains unanswered in the internal fork, so I leave it unanswered here as well.