### PR TITLE
Make healthcheck config fetch interval configurable

### DIFF
--- a/binaries/seesaw_healthcheck/main.go
+++ b/binaries/seesaw_healthcheck/main.go
@@ -51,6 +51,10 @@ var (
 		healthcheck.DefaultServerConfig().NotifyInterval,
 		"The time between notifications")
 
+	fetchInterval = flag.Duration("fetch_interval",
+		healthcheck.DefaultServerConfig().FetchInterval,
+		"The time between healthcheck config fetches from the Engine")
+
 	retryDelay = flag.Duration("retry_delay",
 		healthcheck.DefaultServerConfig().RetryDelay,
 		"The time between notification RPC retries")
@@ -71,6 +75,7 @@ func main() {
 	cfg.EngineSocket = *engineSocket
 	cfg.MaxFailures = *maxFailures
 	cfg.NotifyInterval = *notifyInterval
+	cfg.FetchInterval = *fetchInterval
 	cfg.RetryDelay = *retryDelay
 	cfg.DryRun = *dryRun
 

--- a/healthcheck/core.go
+++ b/healthcheck/core.go
@@ -418,6 +418,7 @@ type ServerConfig struct {
 	EngineSocket   string
 	MaxFailures    int
 	NotifyInterval time.Duration
+	FetchInterval  time.Duration
 	RetryDelay     time.Duration
 	DryRun         bool
 }
@@ -429,6 +430,7 @@ var defaultServerConfig = ServerConfig{
 	EngineSocket:   seesaw.EngineSocket,
 	MaxFailures:    10,
 	NotifyInterval: 15 * time.Second,
+	FetchInterval:  15 * time.Second,
 	RetryDelay:     2 * time.Second,
 }
 
@@ -517,7 +519,7 @@ func (s *Server) updater() {
 		} else {
 			log.Infof("Engine returned %d healthchecks", len(checks.Configs))
 			s.configs <- checks.Configs
-			time.Sleep(15 * time.Second)
+			time.Sleep(s.config.FetchInterval)
 		}
 	}
 }


### PR DESCRIPTION
Expose -fetch_interval to decide how often seesaw_healthcheck fetches
config from seesaw_engine. Default is 15 seconds.