### PR TITLE
Resolve some lint warnings

### DIFF
--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -45,6 +45,7 @@ var defaultArchiveConfig = archiveConfig{
 // Source specifies a source of configuration information.
 type Source int
 
+// Values for Source.
 const (
 	SourceNone Source = iota
 	SourceDisk
@@ -339,13 +340,13 @@ func addNodes(c *Cluster, p *pb.Cluster) error {
 	for _, n := range c.Nodes {
 		nodes = append(nodes, n)
 	}
-	sort.Sort(seesaw.NodesByIPv4{nodes})
+	sort.Sort(seesaw.NodesByIPv4{Nodes: nodes})
 	for i, n := range nodes {
 		if i == 0 {
 			n.Priority = 255
 			continue
 		}
-		n.Priority = uint8(len(nodes)-i)
+		n.Priority = uint8(len(nodes) - i)
 	}
 	return nil
 }

--- a/engine/config/config_test.go
+++ b/engine/config/config_test.go
@@ -400,8 +400,8 @@ var vserverTests = []struct {
 				},
 				map[string]*seesaw.VIP{
 					"192.168.255.1 (Anycast)": {
-						seesaw.NewIP(net.ParseIP("192.168.255.1")),
-						seesaw.AnycastVIP,
+						IP:   seesaw.NewIP(net.ParseIP("192.168.255.1")),
+						Type: seesaw.AnycastVIP,
 					},
 				},
 				true,
@@ -437,12 +437,12 @@ var vserverTests = []struct {
 				make(map[string]*Healthcheck),
 				map[string]*seesaw.VIP{
 					"192.168.36.1 (Dedicated)": {
-						seesaw.NewIP(net.ParseIP("192.168.36.1")),
-						seesaw.DedicatedVIP,
+						IP:   seesaw.NewIP(net.ParseIP("192.168.36.1")),
+						Type: seesaw.DedicatedVIP,
 					},
 					"2015:cafe:36:0:a800:1ff:ffee:dd01 (Dedicated)": {
-						seesaw.NewIP(net.ParseIP("2015:cafe:36::a800:1ff:ffee:dd01")),
-						seesaw.DedicatedVIP,
+						IP:   seesaw.NewIP(net.ParseIP("2015:cafe:36::a800:1ff:ffee:dd01")),
+						Type: seesaw.DedicatedVIP,
 					},
 				},
 				true,
@@ -522,8 +522,8 @@ var vserverTests = []struct {
 				},
 				map[string]*seesaw.VIP{
 					"192.168.255.2 (Anycast)": {
-						seesaw.NewIP(net.ParseIP("192.168.255.2")),
-						seesaw.AnycastVIP,
+						IP:   seesaw.NewIP(net.ParseIP("192.168.255.2")),
+						Type: seesaw.AnycastVIP,
 					},
 				},
 				true,
@@ -558,12 +558,12 @@ var vserverTests = []struct {
 				make(map[string]*Healthcheck),
 				map[string]*seesaw.VIP{
 					"192.168.36.1 (Unicast)": {
-						seesaw.NewIP(net.ParseIP("192.168.36.1")),
-						seesaw.UnicastVIP,
+						IP:   seesaw.NewIP(net.ParseIP("192.168.36.1")),
+						Type: seesaw.UnicastVIP,
 					},
 					"2015:cafe:36:0:a800:1ff:ffee:dd01 (Unicast)": {
-						seesaw.NewIP(net.ParseIP("2015:cafe:36::a800:1ff:ffee:dd01")),
-						seesaw.UnicastVIP,
+						IP:   seesaw.NewIP(net.ParseIP("2015:cafe:36::a800:1ff:ffee:dd01")),
+						Type: seesaw.UnicastVIP,
 					},
 				},
 				true,

--- a/engine/ha.go
+++ b/engine/ha.go
@@ -103,11 +103,7 @@ func (h *haManager) requestFailover(peer bool) error {
 		return fmt.Errorf("Node is not master (current state is %v)", state)
 	}
 
-	if err := h.engine.syncClient.failover(); err != nil {
-		return err
-	}
-
-	return nil
+	return h.engine.syncClient.failover()
 }
 
 // setState sets the HAState of the engine and dispatches events when the state

--- a/engine/healthcheck.go
+++ b/engine/healthcheck.go
@@ -383,7 +383,7 @@ func (h *healthcheckManager) expire() {
 
 	status := healthcheck.Status{State: healthcheck.StateUnknown}
 	for _, id := range ids {
-		h.queueHealthState(&healthcheck.Notification{id, status})
+		h.queueHealthState(&healthcheck.Notification{Id: id, Status: status})
 	}
 }
 

--- a/engine/sync.go
+++ b/engine/sync.go
@@ -51,6 +51,7 @@ type SyncSessionID uint64
 // SyncNoteType specifies the type of a synchronisation notification.
 type SyncNoteType int
 
+// Values for SyncNoteType.
 const (
 	SNTHeartbeat SyncNoteType = iota
 	SNTDesync
@@ -417,10 +418,7 @@ func (sc *syncClient) failover() error {
 		return err
 	}
 	defer sc.close()
-	if err := sc.client.Call("SeesawSync.Failover", 0, nil); err != nil {
-		return err
-	}
-	return nil
+	return sc.client.Call("SeesawSync.Failover", 0, nil)
 }
 
 // runOnce establishes a connection to the synchronisation server, registers

--- a/engine/vserver.go
+++ b/engine/vserver.go
@@ -108,31 +108,31 @@ type service struct {
 }
 
 // ipvsService returns an IPVS Service for the given service.
-func (svc *service) ipvsService() *ipvs.Service {
+func (s *service) ipvsService() *ipvs.Service {
 	var flags ipvs.ServiceFlags
-	if svc.ventry.Persistence > 0 {
+	if s.ventry.Persistence > 0 {
 		flags |= ipvs.SFPersistent
 	}
-	if svc.ventry.OnePacket {
+	if s.ventry.OnePacket {
 		flags |= ipvs.SFOnePacket
 	}
 	var ip net.IP
 	switch {
-	case svc.fwm > 0 && svc.af == seesaw.IPv4:
+	case s.fwm > 0 && s.af == seesaw.IPv4:
 		ip = net.IPv4zero
-	case svc.fwm > 0 && svc.af == seesaw.IPv6:
+	case s.fwm > 0 && s.af == seesaw.IPv6:
 		ip = net.IPv6zero
 	default:
-		ip = svc.ip.IP()
+		ip = s.ip.IP()
 	}
 	return &ipvs.Service{
 		Address:      ip,
-		Protocol:     ipvs.IPProto(svc.proto),
-		Port:         svc.port,
-		Scheduler:    svc.ventry.Scheduler.String(),
-		FirewallMark: svc.fwm,
+		Protocol:     ipvs.IPProto(s.proto),
+		Port:         s.port,
+		Scheduler:    s.ventry.Scheduler.String(),
+		FirewallMark: s.fwm,
 		Flags:        flags,
-		Timeout:      uint32(svc.ventry.Persistence),
+		Timeout:      uint32(s.ventry.Persistence),
 	}
 }
 
@@ -179,23 +179,23 @@ type destination struct {
 }
 
 // ipvsDestination returns an IPVS Destination for the given destination.
-func (dst *destination) ipvsDestination() *ipvs.Destination {
+func (d *destination) ipvsDestination() *ipvs.Destination {
 	var flags ipvs.DestinationFlags
-	switch dst.service.ventry.Mode {
+	switch d.service.ventry.Mode {
 	case seesaw.LBModeNone:
-		log.Warningf("%v: Unspecified LB mode", dst)
+		log.Warningf("%v: Unspecified LB mode", d)
 	case seesaw.LBModeDSR:
 		flags |= ipvs.DFForwardRoute
 	case seesaw.LBModeNAT:
 		flags |= ipvs.DFForwardMasq
 	}
 	return &ipvs.Destination{
-		Address:        dst.ip.IP(),
-		Port:           dst.service.port,
-		Weight:         dst.weight,
+		Address:        d.ip.IP(),
+		Port:           d.service.port,
+		Weight:         d.weight,
 		Flags:          flags,
-		LowerThreshold: uint32(dst.service.ventry.LThreshold),
-		UpperThreshold: uint32(dst.service.ventry.UThreshold),
+		LowerThreshold: uint32(d.service.ventry.LThreshold),
+		UpperThreshold: uint32(d.service.ventry.UThreshold),
 	}
 }
 

--- a/engine/vserver_test.go
+++ b/engine/vserver_test.go
@@ -117,7 +117,7 @@ var expectedServices = map[serviceKey]struct {
 	ip            seesaw.IP
 	expectedDests []destination
 }{
-	serviceKey{
+	{
 		af:    seesaw.IPv4,
 		proto: seesaw.IPProtoUDP,
 		port:  53,
@@ -128,7 +128,7 @@ var expectedServices = map[serviceKey]struct {
 			{destinationKey: newDestinationKey(net.ParseIP("1.1.1.11")), stats: &seesaw.DestinationStats{}},
 		},
 	},
-	serviceKey{
+	{
 		af:    seesaw.IPv4,
 		proto: seesaw.IPProtoTCP,
 		port:  8053,
@@ -139,7 +139,7 @@ var expectedServices = map[serviceKey]struct {
 			{destinationKey: newDestinationKey(net.ParseIP("1.1.1.11")), stats: &seesaw.DestinationStats{}},
 		},
 	},
-	serviceKey{
+	{
 		af:    seesaw.IPv6,
 		proto: seesaw.IPProtoUDP,
 		port:  53,
@@ -150,7 +150,7 @@ var expectedServices = map[serviceKey]struct {
 			{destinationKey: newDestinationKey(net.ParseIP("2012::11")), stats: &seesaw.DestinationStats{}},
 		},
 	},
-	serviceKey{
+	{
 		af:    seesaw.IPv6,
 		proto: seesaw.IPProtoTCP,
 		port:  8053,
@@ -167,7 +167,7 @@ var expectedFWMServices = map[serviceKey]struct {
 	ip            seesaw.IP
 	expectedDests []destination
 }{
-	serviceKey{
+	{
 		af:  seesaw.IPv4,
 		fwm: fwmAllocBase + 0,
 	}: {
@@ -177,7 +177,7 @@ var expectedFWMServices = map[serviceKey]struct {
 			{destinationKey: newDestinationKey(net.ParseIP("1.1.1.11")), stats: &seesaw.DestinationStats{}},
 		},
 	},
-	serviceKey{
+	{
 		af:  seesaw.IPv6,
 		fwm: fwmAllocBase + 1,
 	}: {
@@ -314,69 +314,69 @@ var expectedServiceStates = map[serviceKey]struct {
 	testStates
 	dests map[destinationKey]testStates
 }{
-	serviceKey{seesaw.IPv4, 0, seesaw.IPProtoUDP, 53}: {
+	{seesaw.IPv4, 0, seesaw.IPProtoUDP, 53}: {
 		seesaw.ParseIP("192.168.255.1"),
 		testStates{
 			active:  []bool{false, false, true, true, false, false, false},
 			healthy: []bool{false, false, true, true, false, false, false},
 		},
 		map[destinationKey]testStates{
-			destinationKey{seesaw.ParseIP("1.1.1.10")}: {
+			{seesaw.ParseIP("1.1.1.10")}: {
 				active:  []bool{false, false, true, false, false, false, false},
 				healthy: []bool{false, false, true, false, false, false, false},
 			},
-			destinationKey{seesaw.ParseIP("1.1.1.11")}: {
+			{seesaw.ParseIP("1.1.1.11")}: {
 				active:  []bool{false, false, true, true, false, false, false},
 				healthy: []bool{false, false, true, true, false, false, false},
 			},
 		},
 	},
-	serviceKey{seesaw.IPv4, 0, seesaw.IPProtoTCP, 8053}: {
+	{seesaw.IPv4, 0, seesaw.IPProtoTCP, 8053}: {
 		seesaw.ParseIP("192.168.255.1"),
 		testStates{
 			active:  []bool{false, false, true, true, false, false, false},
 			healthy: []bool{false, false, true, true, true, true, false},
 		},
 		map[destinationKey]testStates{
-			destinationKey{seesaw.ParseIP("1.1.1.10")}: {
+			{seesaw.ParseIP("1.1.1.10")}: {
 				active:  []bool{false, false, true, true, false, false, false},
 				healthy: []bool{false, false, true, true, true, true, false},
 			},
-			destinationKey{seesaw.ParseIP("1.1.1.11")}: {
+			{seesaw.ParseIP("1.1.1.11")}: {
 				active:  []bool{false, false, true, true, false, false, false},
 				healthy: []bool{false, false, true, true, true, true, false},
 			},
 		},
 	},
-	serviceKey{seesaw.IPv6, 0, seesaw.IPProtoUDP, 53}: {
+	{seesaw.IPv6, 0, seesaw.IPProtoUDP, 53}: {
 		seesaw.ParseIP("2012::1"),
 		testStates{
 			active:  []bool{false, false, true, true, true, false, false},
 			healthy: []bool{false, false, true, true, true, false, false},
 		},
 		map[destinationKey]testStates{
-			destinationKey{seesaw.ParseIP("2012::10")}: {
+			{seesaw.ParseIP("2012::10")}: {
 				active:  []bool{false, false, true, true, true, false, false},
 				healthy: []bool{false, false, true, true, true, false, false},
 			},
-			destinationKey{seesaw.ParseIP("2012::11")}: {
+			{seesaw.ParseIP("2012::11")}: {
 				active:  []bool{false, false, true, true, true, false, false},
 				healthy: []bool{false, false, true, true, true, false, false},
 			},
 		},
 	},
-	serviceKey{seesaw.IPv6, 0, seesaw.IPProtoTCP, 8053}: {
+	{seesaw.IPv6, 0, seesaw.IPProtoTCP, 8053}: {
 		seesaw.ParseIP("2012::1"),
 		testStates{
 			active:  []bool{false, false, true, true, true, true, false},
 			healthy: []bool{false, false, true, true, true, true, false},
 		},
 		map[destinationKey]testStates{
-			destinationKey{seesaw.ParseIP("2012::10")}: {
+			{seesaw.ParseIP("2012::10")}: {
 				active:  []bool{false, false, true, true, true, true, false},
 				healthy: []bool{false, false, true, true, true, true, false},
 			},
-			destinationKey{seesaw.ParseIP("2012::11")}: {
+			{seesaw.ParseIP("2012::11")}: {
 				active:  []bool{false, false, true, true, true, true, false},
 				healthy: []bool{false, false, true, true, true, true, false},
 			},
@@ -706,7 +706,10 @@ func TestVserverOverride(t *testing.T) {
 
 	// Disable the vserver with an Override.
 	var o seesaw.Override
-	o = &seesaw.VserverOverride{vserverConfig.Name, seesaw.OverrideDisable}
+	o = &seesaw.VserverOverride{
+		VserverName:   vserverConfig.Name,
+		OverrideState: seesaw.OverrideDisable,
+	}
 	vserver.handleOverride(o)
 
 	// The vserver should still have the same number of services.
@@ -731,7 +734,10 @@ func TestVserverOverride(t *testing.T) {
 	}
 
 	// Bring it back.
-	o = &seesaw.VserverOverride{vserverConfig.Name, seesaw.OverrideDefault}
+	o = &seesaw.VserverOverride{
+		VserverName:   vserverConfig.Name,
+		OverrideState: seesaw.OverrideDefault,
+	}
 	vserver.handleOverride(o)
 	for _, c := range vserver.checks {
 		n := &checkNotification{key: c.key, status: statusHealthy}
@@ -758,7 +764,10 @@ func TestVserverOverride(t *testing.T) {
 	}
 
 	// Enable the vserver with an Override.
-	o = &seesaw.VserverOverride{vserverConfig.Name, seesaw.OverrideEnable}
+	o = &seesaw.VserverOverride{
+		VserverName:   vserverConfig.Name,
+		OverrideState: seesaw.OverrideEnable,
+	}
 	vserver.handleOverride(o)
 	for _, c := range vserver.checks {
 		n := &checkNotification{key: c.key, status: statusHealthy}
@@ -780,7 +789,10 @@ func TestVserverOverride(t *testing.T) {
 	}
 
 	// Remove the enable override, nothing should change.
-	o = &seesaw.VserverOverride{vserverConfig.Name, seesaw.OverrideDefault}
+	o = &seesaw.VserverOverride{
+		VserverName:   vserverConfig.Name,
+		OverrideState: seesaw.OverrideDefault,
+	}
 	vserver.handleOverride(o)
 	for _, err := range checkAllUp(vserver) {
 		t.Error(err)


### PR DESCRIPTION
- Remove redundant types in map literals
- De-verbose trailing `if err != nil { return err } return nil`
- Add a couple of missing doc comments
- Add field names in struct literals
- Make some method receiver names consistent