### PR TITLE
Fix the race condition in TestSyncHeartbeats test case

### DIFF
--- a/engine/sync_test.go
+++ b/engine/sync_test.go
@@ -137,10 +137,6 @@ func TestSyncHeartbeats(t *testing.T) {
 	go client.run()
 
 	client.enable()
-	client.disable()
-	time.Sleep(500 * time.Millisecond)
-
-	client.enable()
 	time.Sleep(1500 * time.Millisecond)
 	client.disable()
 


### PR DESCRIPTION
Context: It is found in CI pipeline that TestSyncHeartbeats case could fail
occasionally, with the following error message.

```
--- FAIL: TestSyncHeartbeats (6.53s)
    sync_test.go:156: Got Desynchronisation sync note
    sync_test.go:154: Got sync note Desynchronisation, want Heartbeat
    sync_test.go:156: Got Desynchronisation sync note
    sync_test.go:156: Got Heartbeat sync note
```

And it is caused by the 3 lines this change is trying to remove.

Analysis: syncClient.poll() triggers an asynchronous rpc call on Poll method,
which may (rarely happen) or may not (most cases) completes before syncClient
got disabled. Should Poll actually succeeded, sync client will then receive an
extra `SNTDesync` note, and fail the test case with the above message.

This change removes the racy lines from the test case and let the rest code in
TestSyncHeartbeats cover the flow of heartbeat note.