### PR TITLE
Improve sync_test.go, add time to SyncNote

### DIFF
--- a/engine/core.go
+++ b/engine/core.go
@@ -376,7 +376,7 @@ func (e *Engine) manager() {
 
 		case n := <-e.notifier.C:
 			log.Infof("Received cluster config notification; %v", &n)
-			e.syncServer.notify(&SyncNote{Type: SNTConfigUpdate})
+			e.syncServer.notify(&SyncNote{Type: SNTConfigUpdate, Time: time.Now()})
 
 			e.clusterLock.Lock()
 			e.cluster = n.Cluster
@@ -427,7 +427,7 @@ func (e *Engine) manager() {
 			e.vserverLock.Unlock()
 
 		case override := <-e.overrideChan:
-			sn := &SyncNote{Type: SNTOverride}
+			sn := &SyncNote{Type: SNTOverride, Time: time.Now()}
 			switch o := override.(type) {
 			case *seesaw.BackendOverride:
 				sn.BackendOverride = o

--- a/engine/sync.go
+++ b/engine/sync.go
@@ -80,6 +80,7 @@ func (snt SyncNoteType) String() string {
 // SyncNote represents a synchronisation notification.
 type SyncNote struct {
 	Type SyncNoteType
+	Time time.Time
 
 	Config      *config.Notification
 	Healthcheck *SyncHealthCheckNotification
@@ -107,19 +108,10 @@ func (s *SeesawSync) Register(node net.IP, id *SyncSessionID) error {
 
 	// TODO(jsing): Reject if not master?
 
-	s.sync.sessionLock.Lock()
-	session := newSyncSession(node, s.sync.nextSessionID)
-	s.sync.nextSessionID++
-	s.sync.sessions[session.id] = session
-	s.sync.sessionLock.Unlock()
-
-	session.Lock()
-	session.expiryTime = time.Now().Add(sessionDeadtime)
-	session.Unlock()
+	session := s.sync.newSession(node)
+	log.Infof("Synchronisation session %d registered by %v", session.id, node)
 
 	*id = session.id
-
-	log.Infof("Synchronisation session %d registered by %v", *id, node)
 
 	return nil
 }
@@ -158,7 +150,7 @@ func (s *SeesawSync) Poll(id SyncSessionID, sn *SyncNotes) error {
 	session.expiryTime = time.Now().Add(sessionDeadtime)
 	if session.desync {
 		// TODO(jsing): Discard pending notes?
-		sn.Notes = append(sn.Notes, SyncNote{Type: SNTDesync})
+		sn.Notes = append(sn.Notes, SyncNote{Type: SNTDesync, Time: time.Now()})
 		session.desync = false
 		session.Unlock()
 		return nil
@@ -262,6 +254,18 @@ func newSyncServer(e *Engine) *syncServer {
 	}
 }
 
+// newSession allocates a new session ID and starts managing the session with
+// the provided node.
+func (s *syncServer) newSession(node net.IP) *syncSession {
+	s.sessionLock.Lock()
+	session := newSyncSession(node, s.nextSessionID)
+	s.nextSessionID++
+	s.sessions[session.id] = session
+	s.sessionLock.Unlock()
+
+	return session
+}
+
 // serve accepts connections from the given TCP listener and dispatches each
 // connection to the RPC server. Connections are only accepted from localhost
 // and the seesaw node that we are configured to peer with.
@@ -311,26 +315,21 @@ func (s *syncServer) notify(sn *SyncNote) {
 
 // run runs the synchronisation server, which is responsible for queueing
 // heartbeat notifications and removing expired synchronisation sessions.
-func (s *syncServer) run() error {
-	heartbeat := time.NewTicker(s.heartbeatInterval)
-	for {
-		select {
-		case <-heartbeat.C:
-			now := time.Now()
-			s.sessionLock.Lock()
-			for id, ss := range s.sessions {
-				ss.RLock()
-				expiry := ss.expiryTime
-				ss.RUnlock()
-				if now.After(expiry) {
-					log.Warningf("Sync session %d with %v has expired", id, ss.node)
-					delete(s.sessions, id)
-					continue
-				}
-				ss.addNote(&SyncNote{Type: SNTHeartbeat})
+func (s *syncServer) run() {
+	for now := range time.Tick(s.heartbeatInterval) {
+		s.sessionLock.Lock()
+		for id, ss := range s.sessions {
+			ss.RLock()
+			expiry := ss.expiryTime
+			ss.RUnlock()
+			if now.After(expiry) {
+				log.Warningf("Sync session %d with %v has expired", id, ss.node)
+				delete(s.sessions, id)
+				continue
 			}
-			s.sessionLock.Unlock()
+			ss.addNote(&SyncNote{Type: SNTHeartbeat, Time: now})
 		}
+		s.sessionLock.Unlock()
 	}
 }
 
@@ -535,7 +534,7 @@ func (sc *syncClient) handleOverride(sn *SyncNote) {
 }
 
 // run runs the synchronisation client.
-func (sc *syncClient) run() error {
+func (sc *syncClient) run() {
 	for {
 		select {
 		case <-sc.stopped:
@@ -544,6 +543,8 @@ func (sc *syncClient) run() error {
 		default:
 			sc.runOnce()
 			select {
+			// TODO: If we receive on quit inside runOnce, we have to wait the
+			// 5s here before enable will work again.
 			case <-time.After(5 * time.Second):
 			case <-sc.quit:
 				sc.stopped <- true

--- a/engine/sync_test.go
+++ b/engine/sync_test.go
@@ -125,8 +125,6 @@ func TestSyncHeartbeats(t *testing.T) {
 	go server.run()
 	go client.run()
 
-	// TODO: Test we can disable and re-enable the client
-
 	// Enabling briefly shouldn't have time to get a heartbeat, but should get
 	// the initial desync.
 	client.enable()


### PR DESCRIPTION
- sync.go: Add time of message to SyncNote, to aid debugging
- various: Set the new Time field
- sync_test.go: Add clarifying comments
- sync_test.go: Clean up some test failure messages
- sync_test.go: Remove named return args on newSyncTest
- sync_test.go: IPv4/v6 distinction not used, so remove arg from newLocalTCPListener
- sync.go: Minor refactor of sync session creation into own method
- sync.go: Cleanup of infinite loop + one-case select -> range over ticker

This upstreams some work by @baptr.