### PR TITLE
Support disabling vrrp mac

### DIFF
--- a/binaries/seesaw_engine/main.go
+++ b/binaries/seesaw_engine/main.go
@@ -23,6 +23,7 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/google/seesaw/common/seesaw"
 	"github.com/google/seesaw/common/server"
@@ -114,6 +115,23 @@ func main() {
 		log.Exitf("Unable to get cluster peer_ipv6: %v", err)
 	}
 
+	useVMAC := config.DefaultEngineConfig().UseVMAC
+	if cfg.HasOption("cluster", "use_vmac") {
+		uv, err := cfg.GetBool("cluster", "use_vmac")
+		if err != nil {
+			log.Exitf("Unable to get use_vmac: %v", err)
+		}
+		useVMAC = uv
+	}
+	garpInterval := config.DefaultEngineConfig().GratuitousARPInterval
+	if cfg.HasOption("cluster", "garp_interval_sec") {
+		it, err := cfg.GetInt("cluster", "garp_interval_sec")
+		if err != nil {
+			log.Exitf("Unable to get garp_interval_sec: %v", err)
+		}
+		garpInterval = time.Duration(it) * time.Second
+	}
+
 	// The default VRID may be overridden via the config file.
 	vrid := config.DefaultEngineConfig().VRID
 	if cfg.HasOption("cluster", "vrid") {
@@ -191,6 +209,8 @@ func main() {
 	engineCfg.ServiceAnycastIPv6 = serviceAnycastIPv6
 	engineCfg.SocketPath = *socketPath
 	engineCfg.VRID = vrid
+	engineCfg.UseVMAC = useVMAC
+	engineCfg.GratuitousARPInterval = garpInterval
 
 	// removes previous leftover socket.
 	if err := server.RemoveUnixSocket(engineCfg.SocketPath); err != nil {

--- a/engine/config/engine.go
+++ b/engine/config/engine.go
@@ -50,6 +50,7 @@ var defaultEngineConfig = EngineConfig{
 	SocketPath:              seesaw.EngineSocket,
 	StatsInterval:           15 * time.Second,
 	SyncPort:                10258,
+	UseVMAC:                 true,
 	VRID:                    60,
 	VRRPDestIP:              net.ParseIP("224.0.0.18"),
 }
@@ -87,6 +88,7 @@ type EngineConfig struct {
 	SocketPath              string        // The path to the engine socket.
 	StatsInterval           time.Duration // The statistics update interval.
 	SyncPort                int           // The port for sync'ing with this node's peer.
+	UseVMAC                 bool          // Use VRRP MAC. If false, Seesaw uses gratuitous arp for failover (ipv6 not supported yet). Default true.
 	VMAC                    string        // The VMAC address to use for the load balancing network interface.
 	VRID                    uint8         // The VRRP virtual router ID for the cluster.
 	VRRPDestIP              net.IP        // The destination IP for VRRP advertisements.

--- a/ncc/client/dummy.go
+++ b/ncc/client/dummy.go
@@ -43,7 +43,7 @@ func (nc *dummyNCC) NewLBInterface(name string, cfg *ncctypes.LBConfig) LBInterf
 }
 func (nc *dummyNCC) Dial() error                                                          { return nil }
 func (nc *dummyNCC) Close() error                                                         { return nil }
-func (nc *dummyNCC) ARPSendGratuitous(iface string, ip net.IP) error                      { return nil }
+func (nc *dummyNCC) ARPSendGratuitous(arpMap map[string][]net.IP) error                   { return nil }
 func (nc *dummyNCC) BGPConfig() ([]string, error)                                         { return nil, nil }
 func (nc *dummyNCC) BGPNeighbors() ([]*quagga.Neighbor, error)                            { return nil, nil }
 func (nc *dummyNCC) BGPWithdrawAll() error                                                { return nil }

--- a/ncc/client/ncc_client.go
+++ b/ncc/client/ncc_client.go
@@ -46,7 +46,7 @@ type NCC interface {
 	Close() error
 
 	// ARPSendGratuitous sends a gratuitious ARP message.
-	ARPSendGratuitous(iface string, ip net.IP) error
+	ARPSendGratuitous(map[string][]net.IP) error
 
 	// BGPConfig returns the configuration for the Quagga BGP daemon.
 	BGPConfig() ([]string, error)
@@ -196,12 +196,8 @@ func (nc *nccClient) Close() error {
 	return nil
 }
 
-func (nc *nccClient) ARPSendGratuitous(iface string, ip net.IP) error {
-	arp := ncctypes.ARPGratuitous{
-		IfaceName: iface,
-		IP:        ip,
-	}
-	return nc.call("SeesawNCC.ARPSendGratuitous", &arp, nil)
+func (nc *nccClient) ARPSendGratuitous(arpMap map[string][]net.IP) error {
+	return nc.call("SeesawNCC.ARPSendGratuitous", arpMap, nil)
 }
 
 func (nc *nccClient) BGPConfig() ([]string, error) {

--- a/ncc/lb.go
+++ b/ncc/lb.go
@@ -58,12 +58,14 @@ func (ncc *SeesawNCC) LBInterfaceInit(iface *ncctypes.LBInterface, out *int) err
 
 	log.Infof("Initialising load balancing interface %s - VRID %d (VMAC %s)", iface.Name, iface.VRID, vmac)
 
-	// Ensure interface is down and set VMAC address.
+	// Ensure interface is down.
 	if err := ifaceFastDown(netIface); err != nil {
 		return fmt.Errorf("Failed to down interface: %v", err)
 	}
-	if err := ifaceSetMAC(netIface); err != nil {
-		return fmt.Errorf("Failed to set MAC: %v", err)
+	if iface.UseVMAC {
+		if err := ifaceSetMAC(netIface); err != nil {
+			return fmt.Errorf("Failed to set MAC: %v", err)
+		}
 	}
 
 	// Remove VLAN interfaces associated with the load balancing interface.

--- a/ncc/types/ncc_types.go
+++ b/ncc/types/ncc_types.go
@@ -26,12 +26,6 @@ import (
 	"github.com/google/seesaw/quagga"
 )
 
-// ARPGratuitous encapsulates a request to send a gratuitous ARP message.
-type ARPGratuitous struct {
-	IfaceName string
-	IP        net.IP
-}
-
 // BGPNeighbors encapsulates a list of BGP neighbors.
 type BGPNeighbors struct {
 	Neighbors []*quagga.Neighbor
@@ -61,6 +55,7 @@ type LBConfig struct {
 	Node           seesaw.Host
 	RoutingTableID uint8
 	VRID           uint8
+	UseVMAC        bool
 }
 
 // LBInterface represents the load balancing network interface on a Seesaw Node.

--- a/test_tools/ncc_test_tool/main.go
+++ b/test_tools/ncc_test_tool/main.go
@@ -69,7 +69,9 @@ func arpTests(ncc client.NCC) {
 		log.Fatalf("Invalid cluster VIP - %q", *clusterVIPStr)
 	}
 	log.Print("Sending gratuitous ARP...")
-	if err := ncc.ARPSendGratuitous(*testIface, vip); err != nil {
+	if err := ncc.ARPSendGratuitous(map[string][]net.IP{
+		*testIface: []net.IP{vip},
+	}); err != nil {
 		log.Fatalf("Failed to send gratuitous ARP: %v", err)
 	}
 	log.Print("Done.")


### PR DESCRIPTION
This commit adds a flag use_vmac to provide a way not to use vmac.
Machines with the same MAC address can be problematic in certain
scenario like VMs. If not using vmac, it requires GARPs sent for each
service VIPs.