### PR TITLE
enables fallback and port for hashing schedulers

### DIFF
--- a/engine/vserver.go
+++ b/engine/vserver.go
@@ -116,6 +116,14 @@ func (s *service) ipvsService() *ipvs.Service {
 	if s.ventry.OnePacket {
 		flags |= ipvs.SFOnePacket
 	}
+	// Enables fallback and port for hashing schedulers.
+	// Maps to ipvs sh-fallback, sh-port, mh-fallback and mh-port.
+	switch s.ventry.Scheduler {
+	case seesaw.LBSchedulerSH:
+		flags |= ipvs.SFSchedSHFallback | ipvs.SFSchedSHPort
+	case seesaw.LBSchedulerMH:
+		flags |= ipvs.SFSchedMHFallback | ipvs.SFSchedMHPort
+	}
 	var ip net.IP
 	switch {
 	case s.fwm > 0 && s.af == seesaw.IPv4:

--- a/ipvs/ipvs.go
+++ b/ipvs/ipvs.go
@@ -218,9 +218,13 @@ func (f *ServiceFlags) SetBytes(x []byte) {
 }
 
 const (
-	SFPersistent ServiceFlags = ipvsSvcFlagPersist
-	SFHashed     ServiceFlags = ipvsSvcFlagHashed
-	SFOnePacket  ServiceFlags = ipvsSvcFlagOnePacket
+	SFPersistent      ServiceFlags = ipvsSvcFlagPersist
+	SFHashed          ServiceFlags = ipvsSvcFlagHashed
+	SFOnePacket       ServiceFlags = ipvsSvcFlagOnePacket
+	SFSchedSHFallback ServiceFlags = ipvsSvcFlagSchedSHFallback
+	SFSchedSHPort     ServiceFlags = ipvsSvcFlagSchedSHPort
+	SFSchedMHFallback ServiceFlags = ipvsSvcFlagSchedMHFallback
+	SFSchedMHPort     ServiceFlags = ipvsSvcFlagSchedMHPort
 )
 
 // Service represents an IPVS service.
@@ -333,6 +337,14 @@ const (
 	ipvsSvcFlagPersist   = 0x1
 	ipvsSvcFlagHashed    = 0x2
 	ipvsSvcFlagOnePacket = 0x4
+	ipvsSvcFlagSchedOpt1 = 0x8
+	ipvsSvcFlagSchedOpt2 = 0x10
+
+	// Depending on schedulers, the bit stands for different options.
+	ipvsSvcFlagSchedSHFallback = ipvsSvcFlagSchedOpt1
+	ipvsSvcFlagSchedSHPort     = ipvsSvcFlagSchedOpt2
+	ipvsSvcFlagSchedMHFallback = ipvsSvcFlagSchedOpt1
+	ipvsSvcFlagSchedMHPort     = ipvsSvcFlagSchedOpt2
 
 	ipvsDstFlagFwdMask   = 0x7
 	ipvsDstFlagFwdMasq   = 0x0


### PR DESCRIPTION
for sh and mh, by default, port is not included in hashing. This is
against intuition.

This commit enables sh-port and mh-port option.

Also enables sh-fallback and mh-fallback, which is helpful when l/u
threshold set for a service.