### PR TITLE
optimize the tcp healthcheck to reduce the thread usage

### DIFF
--- a/healthcheck/dial.go
+++ b/healthcheck/dial.go
@@ -20,143 +20,50 @@ package healthcheck
 
 import (
 	"errors"
-	"fmt"
 	"net"
 	"os"
-	"strconv"
 	"syscall"
 	"time"
 )
 
 type conn struct {
-	fd int
-	f  *os.File
 	net.Conn
+	mark int
 }
 
 func (c *conn) Close() error {
 	if c.Conn != nil {
-		c.Conn.Close()
-	}
-	if c.f != nil {
-		err := c.f.Close()
-		c.fd, c.f = -1, nil
-		return err
-	}
-	if c.fd != -1 {
-		err := syscall.Close(c.fd)
-		c.fd = -1
-		return err
+		return c.Conn.Close()
 	}
 	return nil
 }
 
-func sockaddrToString(sa syscall.Sockaddr) string {
-	switch sa := sa.(type) {
-	case *syscall.SockaddrInet4:
-		return net.JoinHostPort(net.IP(sa.Addr[:]).String(), strconv.Itoa(sa.Port))
-	case *syscall.SockaddrInet6:
-		return net.JoinHostPort(net.IP(sa.Addr[:]).String(), strconv.Itoa(sa.Port))
-	default:
-		return fmt.Sprintf("(unknown - %T)", sa)
+func (c *conn) control(network, address string, rawc syscall.RawConn) error {
+	var fdErr error
+	ctl := func(fd uintptr) {
+		if c.mark != 0 {
+			fdErr = setSocketMark(int(fd), c.mark)
+		}
 	}
+	if err := rawc.Control(ctl); err != nil {
+		return err
+	}
+	return fdErr
 }
 
 // dialTCP dials a TCP connection to the specified host and sets marking on the
 // socket. The host must be given as an IP address. A mark of zero results in a
 // normal (non-marked) connection.
 func dialTCP(network, addr string, timeout time.Duration, mark int) (nc net.Conn, err error) {
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return nil, err
+	c := &conn{
+		mark: mark,
 	}
-	ip := net.ParseIP(host)
-	if ip == nil {
-		return nil, fmt.Errorf("invalid IP address %q", host)
+	dial := net.Dialer{
+		Timeout: timeout,
+		Control: c.control,
 	}
-	p, err := strconv.ParseUint(port, 10, 16)
-	if err != nil {
-		return nil, fmt.Errorf("invalid port number %q", port)
-	}
-
-	var domain int
-	var rsa syscall.Sockaddr
-	switch network {
-	case "tcp4":
-		domain = syscall.AF_INET
-		if ip.To4() == nil {
-			return nil, fmt.Errorf("invalid IPv4 address %q", host)
-		}
-		sa := &syscall.SockaddrInet4{Port: int(p)}
-		copy(sa.Addr[:], ip.To4())
-		rsa = sa
-
-	case "tcp6":
-		domain = syscall.AF_INET6
-		if ip.To4() != nil {
-			return nil, fmt.Errorf("invalid IPv6 address %q", host)
-		}
-		sa := &syscall.SockaddrInet6{Port: int(p)}
-		copy(sa.Addr[:], ip.To16())
-		rsa = sa
-
-	default:
-		return nil, fmt.Errorf("unsupported network %q", network)
-	}
-
-	c := &conn{}
-
-	defer func() {
-		if err != nil {
-			c.Close()
-		}
-	}()
-
-	c.fd, err = syscall.Socket(domain, syscall.SOCK_STREAM|syscall.SOCK_CLOEXEC, 0)
-	if err != nil {
-		return nil, os.NewSyscallError("socket", err)
-	}
-
-	if mark != 0 {
-		if err := setSocketMark(c.fd, mark); err != nil {
-			return nil, err
-		}
-	}
-
-	if err := setSocketTimeout(c.fd, timeout); err != nil {
-		return nil, err
-	}
-	for {
-		err := syscall.Connect(c.fd, rsa)
-		if err == nil {
-			break
-		}
-		// Blocking socket connect may be interrupted with EINTR
-		if err != syscall.EINTR {
-			return nil, os.NewSyscallError("connect", err)
-		}
-	}
-	if err := setSocketTimeout(c.fd, 0); err != nil {
-		return nil, err
-	}
-
-	lsa, _ := syscall.Getsockname(c.fd)
-	rsa, _ = syscall.Getpeername(c.fd)
-	name := fmt.Sprintf("%s %s -> %s", network, sockaddrToString(lsa), sockaddrToString(rsa))
-	c.f = os.NewFile(uintptr(c.fd), name)
-
-	// When we call net.FileConn the socket will be made non-blocking and
-	// we will get a *net.TCPConn in return. The *os.File needs to be
-	// closed in addition to the *net.TCPConn when we're done (conn.Close
-	// takes care of that for us).
-	if c.Conn, err = net.FileConn(c.f); err != nil {
-		return nil, err
-	}
-	if _, ok := c.Conn.(*net.TCPConn); !ok {
-		return nil, fmt.Errorf("%T is not a *net.TCPConn", c.Conn)
-	}
-
-	return c, nil
+	c.Conn, err = dial.Dial(network, addr)
+	return c, err
 }
 
 // dialUDP dials a UDP connection to the specified host and sets marking on the


### PR DESCRIPTION
For the golang goroutine scheduler algorithm (GMP model), if the gorouting calls a blocking system call, the current P will not release the current M (thread). If there is another G want to run, a new M (thread) must be created. 
Current tcp health check use syscall.Connect to connect to the target. If there are  many goroutines which call tcp health check at the same time, golang may create thousands of threads. 

Actually, golang runtime has provided the dial package to optimize this issue which will use the netpoll unblocking I/O.
In my test env, I run 100000 goroutine,  golang create nearly 8000 thread which is up to the max thread(10000) that golang can support by default.

With the fix in this PR, the thread number is only about 120.