### PR TITLE
cluster.pb.example: fix radius1-2.example.com's IP address.

### DIFF
--- a/etc/seesaw/cluster.pb.example
+++ b/etc/seesaw/cluster.pb.example
@@ -62,7 +62,7 @@ vserver: <
   backend: <
     host: <
       fqdn: "radius1-2.example.com."
-      ipv4: "192.168.11.1/24"
+      ipv4: "192.168.11.2/24"
       status: PRODUCTION
     >
     weight: 1


### PR DESCRIPTION
Give radius1-2.example.com a distinct IP address from radius1-1.example.com's IP address.