### PR TITLE
Update the required `go` version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04]
-        go: [1.13, 1.12]
+        go: [1.17, 1.18]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04]
-        go: [1.17, 1.18]
+        go: [1.19, 1.18]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2

--- a/README.md
+++ b/README.md
@@ -41,15 +41,11 @@ by running:
     apt-get install golang
     apt-get install libnl-3-dev libnl-genl-3-dev
 
-If your distro has a go version before 1.17, you may need to fetch a newer
+If your distro has a go version before 1.18, you may need to fetch a newer
 release from https://golang.org/dl/.
 
-If you are running go version 1.11 and above, you can use go modules to avoid
-installing go packages manually. By go 1.12, `GO111MODULE` defaults to `auto`,
-so remember to enable go module by `export GO111MODULE=on`.
-
-If you are running before go version 1.11 or you don't want to enable
-GO111MODULE, after setting `GOPATH` to an appropriate location (for example `~/go`):
+If you are running before go version 1.11 or you want to set `GO111MODULE=off`,
+after setting `GOPATH` to an appropriate location (for example `~/go`):
 
     go get -u golang.org/x/crypto/ssh
     go get -u github.com/dlintw/goconf

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ by running:
     apt-get install golang
     apt-get install libnl-3-dev libnl-genl-3-dev
 
-If your distro has a go version before 1.5, you may need to fetch a newer
+If your distro has a go version before 1.17, you may need to fetch a newer
 release from https://golang.org/dl/.
 
 If you are running go version 1.11 and above, you can use go modules to avoid

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/seesaw
 
-go 1.17
+go 1.18
 
 require (
 	github.com/dlintw/goconf v0.0.0-20120228082610-dcc070983490

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/google/seesaw
 
-go 1.12
+go 1.17
 
 require (
 	github.com/dlintw/goconf v0.0.0-20120228082610-dcc070983490
-	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.4.0
 	github.com/kylelemons/godebug v1.1.0
@@ -12,4 +11,10 @@ require (
 	golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876
 	google.golang.org/protobuf v1.23.0
 	gopkg.in/fsnotify.v1 v1.4.7
+)
+
+require (
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	golang.org/x/net v0.0.0-20190923162816-aa69164e4478 // indirect
+	golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,7 +23,6 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876 h1:sKJQZMuxjOAR/Uo2LBfU90onWEf1dF4C+0hPJCc9Mpc=
 golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
-golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
@@ -31,9 +30,7 @@ golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe h1:6fAMxZRR6sl1Uq8U61gxU+kPTs2tR8uOySCbBP7BN/M=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9 h1:L2auWcuQIvxz9xSEqzESnV/QN/gNRXNApHi3fYwl2w0=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
We need to update our dependencies due to some security advisories, however the minimum required version for those dependencies is 1.17.
Unfortunately we can't use 1.17 since that causes panics, so we go with 1.18.

From https://github.com/google/seesaw/actions/runs/4282570034/jobs/7457012337:

```
fatal error: checkptr: converted pointer straddles multiple allocations
```